### PR TITLE
feat: replace SMTP with Resend HTTP API for email delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,16 +26,13 @@ CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 # Sync schedule is now configured per-household in Settings > Sync Schedule.
 # No global sync env vars are needed.
 
-# Email (SMTP) — for partner invitation notifications
-# Works with Gmail (smtp.gmail.com), SendGrid (smtp.sendgrid.net), Mailgun, etc.
-# Leave SMTP_HOST empty to disable email sending (invitations still work, just no email)
-SMTP_HOST=
-SMTP_PORT=587
-SMTP_USER=
-SMTP_PASSWORD=
-SMTP_FROM_EMAIL=
-SMTP_FROM_NAME=FinanceApp
-SMTP_USE_TLS=true
+# Email (Resend HTTP API) — for partner invitation & statement reminder notifications
+# Get your API key at https://resend.com/api-keys
+# Leave RESEND_API_KEY empty to disable email sending (invitations still work, just no email)
+RESEND_API_KEY=
+EMAIL_FROM_ADDRESS=
+EMAIL_FROM_NAME=FinanceApp
+# APP_URL is used in email CTAs — set to your public-facing URL in production
 APP_URL=http://localhost:3000
 
 # App

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ python3 -m pytest -v              # verbose output
 python3 -m pytest tests/test_auth.py  # run a single file
 ```
 
-**What's tested (368 tests across 19 files):**
+**What's tested (374 tests across 19 files):**
 
 | File | Tests | Coverage |
 |------|-------|----------|
@@ -592,7 +592,7 @@ python3 -m pytest tests/test_auth.py  # run a single file
 | `test_plaid` | 17 | Link token, exchange token (success, relink, conflict, institution name), sync, sync-all-stream (NDJSON streaming), items (all Plaid calls mocked) |
 | `test_tags` | 13 | CRUD, attach/detach tags, idempotent tagging |
 | `test_reports` | 8 | Spending by category, monthly trends, top merchants |
-| `test_email` | 6 | SMTP service, invitation template, send/skip/fail handling, port-465 SSL |
+| `test_email` | 11 | Resend HTTP API, invitation + statement reminder templates, send/skip/fail/network-error handling, bearer auth, app_url in CTAs |
 | `test_plaid_config` | 13 | GET (configured/not/no-household/member-read), PUT (create/update/non-owner/no-household/invalid-env), DELETE (success/non-owner/not-configured/no-household) |
 | `test_llm_config` | — | BYO LLM config CRUD (owner-only, encryption) |
 | `test_auth` | 8 | Google OAuth login (mocked), session, `/me`, logout, auto-household on signup, no duplicate household on re-login |
@@ -618,7 +618,7 @@ npm run test:watch                # watch mode
 npx vitest run tests/sidebar.test.tsx  # run a single file
 ```
 
-**What's tested (398 tests across 38 files):**
+**What's tested (406 tests across 38 files):**
 
 | File | Tests | Coverage |
 |------|-------|----------|
@@ -669,8 +669,8 @@ npx vitest run tests/sidebar.test.tsx  # run a single file
 
 ### Latest coverage snapshot
 
-- Backend (`pytest --cov=app --cov-report=term`): **85% total** (`3495` statements, `519` missed)
-- Frontend (`pnpm vitest run --coverage`): **76.72% statements**, **71.28% branches**, **62.85% functions**, **77.63% lines**
+- Backend (`pytest --cov=app --cov-report=term`): **85% total** (`3512` statements, `538` missed)
+- Frontend (`npx vitest run --coverage`): **76.66% statements**, **71.65% branches**, **62.78% functions**, **77.56% lines**
 
 ## Environment Variables
 
@@ -693,14 +693,10 @@ npx vitest run tests/sidebar.test.tsx  # run a single file
 | `RATE_LIMIT_TRUST_PROXY` | No | Use `X-Forwarded-For` for client IP (default: `false`) |
 | `RATE_LIMIT_BACKEND` | No | `memory` or `redis` (default: `memory`) |
 | `REDIS_URL` | Required if Redis backend | Redis connection URL (default: `redis://redis:6379/0`) |
-| `SMTP_HOST` | No | SMTP server hostname (empty = email disabled) |
-| `SMTP_PORT` | No | SMTP server port (default: `587`) |
-| `SMTP_USER` | No | SMTP auth username |
-| `SMTP_PASSWORD` | No | SMTP auth password |
-| `SMTP_FROM_EMAIL` | No | Sender email address |
-| `SMTP_FROM_NAME` | No | Sender display name (default: `FinanceApp`) |
-| `SMTP_USE_TLS` | No | Use STARTTLS (default: `true`) |
-| `APP_URL` | No | Frontend URL for email links (default: `http://localhost:3000`) |
+| `RESEND_API_KEY` | No | Resend API key (empty = email disabled) |
+| `EMAIL_FROM_ADDRESS` | No | Sender email address |
+| `EMAIL_FROM_NAME` | No | Sender display name (default: `FinanceApp`) |
+| `APP_URL` | No | Public-facing frontend URL for email CTAs (default: `http://localhost:3000`) |
 
 LLM credentials (base URL, API key, model) are configured per-household in Settings > AI Categorization, not via environment variables.
 

--- a/app/config.py
+++ b/app/config.py
@@ -25,14 +25,10 @@ class Settings(BaseSettings):
     # Sync schedule is now configured per-household in Settings > Sync Schedule.
     # No global sync env vars are needed.
 
-    # Email (SMTP)
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_user: str = ""
-    smtp_password: str = ""
-    smtp_from_email: str = ""
-    smtp_from_name: str = "FinanceApp"
-    smtp_use_tls: bool = True
+    # Email (Resend HTTP API)
+    resend_api_key: str = ""
+    email_from_address: str = ""
+    email_from_name: str = "FinanceApp"
     app_url: str = "http://localhost:3000"
 
     # Server

--- a/app/email.py
+++ b/app/email.py
@@ -1,47 +1,51 @@
-"""Email service for sending notifications via SMTP."""
+"""Email service for sending notifications via Resend HTTP API."""
 
 from __future__ import annotations
 
 import logging
-import smtplib
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+
+import httpx
 
 from app.config import get_settings
 
 logger = logging.getLogger(__name__)
 
+_RESEND_API_URL = "https://api.resend.com/emails"
 
-def _smtp_configured() -> bool:
+
+def _email_configured() -> bool:
     settings = get_settings()
-    return bool(settings.smtp_host and settings.smtp_from_email)
+    return bool(settings.resend_api_key and settings.email_from_address)
 
 
 def _send(to: str, subject: str, html: str) -> bool:
-    """Send an email via SMTP. Returns True on success, False on failure."""
+    """Send an email via the Resend HTTP API. Returns True on success."""
     settings = get_settings()
-    if not _smtp_configured():
-        logger.info("SMTP not configured — skipping email to %s", to)
+    if not _email_configured():
+        logger.info("Email not configured — skipping email to %s", to)
         return False
 
-    msg = MIMEMultipart("alternative")
-    msg["From"] = f"{settings.smtp_from_name} <{settings.smtp_from_email}>"
-    msg["To"] = to
-    msg["Subject"] = subject
-    msg.attach(MIMEText(html, "html"))
-
     try:
-        if settings.smtp_port == 465:
-            server = smtplib.SMTP_SSL(settings.smtp_host, settings.smtp_port, timeout=10)
-        elif settings.smtp_use_tls:
-            server = smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=10)
-            server.starttls()
-        else:
-            server = smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=10)
-        if settings.smtp_user:
-            server.login(settings.smtp_user, settings.smtp_password)
-        server.sendmail(settings.smtp_from_email, to, msg.as_string())
-        server.quit()
+        response = httpx.post(
+            _RESEND_API_URL,
+            headers={
+                "Authorization": f"Bearer {settings.resend_api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "from": f"{settings.email_from_name} <{settings.email_from_address}>",
+                "to": [to],
+                "subject": subject,
+                "html": html,
+            },
+            timeout=10,
+        )
+        if response.status_code >= 400:
+            logger.error(
+                "Resend API error (%d) sending to %s: %s",
+                response.status_code, to, response.text,
+            )
+            return False
         logger.info("Email sent to %s: %s", to, subject)
         return True
     except Exception:

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,24 +1,46 @@
-"""Email service unit tests."""
+"""Email service unit tests (Resend HTTP API)."""
 
 from unittest.mock import patch, MagicMock
 
-from app.email import send_invitation_email, _smtp_configured
+from app.email import (
+    send_invitation_email,
+    send_statement_reminder_email,
+    _email_configured,
+)
 
 
 @patch("app.email.get_settings")
-def test_smtp_not_configured_when_host_empty(mock_settings):
+def test_email_not_configured_when_api_key_empty(mock_settings):
     settings = MagicMock()
-    settings.smtp_host = ""
-    settings.smtp_from_email = ""
+    settings.resend_api_key = ""
+    settings.email_from_address = ""
     mock_settings.return_value = settings
-    assert _smtp_configured() is False
+    assert _email_configured() is False
+
+
+@patch("app.email.get_settings")
+def test_email_not_configured_when_from_address_empty(mock_settings):
+    settings = MagicMock()
+    settings.resend_api_key = "re_test_key"
+    settings.email_from_address = ""
+    mock_settings.return_value = settings
+    assert _email_configured() is False
+
+
+@patch("app.email.get_settings")
+def test_email_configured_when_both_set(mock_settings):
+    settings = MagicMock()
+    settings.resend_api_key = "re_test_key"
+    settings.email_from_address = "noreply@test.com"
+    mock_settings.return_value = settings
+    assert _email_configured() is True
 
 
 @patch("app.email.get_settings")
 def test_send_invitation_skips_when_unconfigured(mock_settings):
     settings = MagicMock()
-    settings.smtp_host = ""
-    settings.smtp_from_email = ""
+    settings.resend_api_key = ""
+    settings.email_from_address = ""
     mock_settings.return_value = settings
     result = send_invitation_email(
         to_email="partner@test.com",
@@ -30,21 +52,19 @@ def test_send_invitation_skips_when_unconfigured(mock_settings):
 
 
 @patch("app.email.get_settings")
-@patch("app.email.smtplib.SMTP")
-def test_send_invitation_success(mock_smtp_cls, mock_settings):
+@patch("app.email.httpx.post")
+def test_send_invitation_success(mock_post, mock_settings):
     settings = MagicMock()
-    settings.smtp_host = "smtp.test.com"
-    settings.smtp_port = 587
-    settings.smtp_user = "user"
-    settings.smtp_password = "pass"
-    settings.smtp_from_email = "noreply@test.com"
-    settings.smtp_from_name = "TestApp"
-    settings.smtp_use_tls = True
-    settings.app_url = "http://localhost:3000"
+    settings.resend_api_key = "re_test_key"
+    settings.email_from_address = "noreply@test.com"
+    settings.email_from_name = "TestApp"
+    settings.app_url = "https://app.example.com"
     mock_settings.return_value = settings
 
-    mock_server = MagicMock()
-    mock_smtp_cls.return_value = mock_server
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "msg_123"}
+    mock_post.return_value = mock_response
 
     result = send_invitation_email(
         to_email="partner@test.com",
@@ -53,29 +73,32 @@ def test_send_invitation_success(mock_smtp_cls, mock_settings):
         household_name="Our Home",
     )
     assert result is True
-    mock_server.starttls.assert_called_once()
-    mock_server.login.assert_called_once_with("user", "pass")
-    mock_server.sendmail.assert_called_once()
-    mock_server.quit.assert_called_once()
+    mock_post.assert_called_once()
 
-    sent_to = mock_server.sendmail.call_args[0][1]
-    assert sent_to == "partner@test.com"
+    call_kwargs = mock_post.call_args
+    assert call_kwargs[0][0] == "https://api.resend.com/emails"
+    payload = call_kwargs[1]["json"]
+    assert payload["to"] == ["partner@test.com"]
+    assert payload["from"] == "TestApp <noreply@test.com>"
+    assert "Alice" in payload["subject"]
+    assert "Our Home" in payload["subject"]
+    assert "https://app.example.com" in payload["html"]
 
 
 @patch("app.email.get_settings")
-@patch("app.email.smtplib.SMTP")
-def test_send_invitation_smtp_failure(mock_smtp_cls, mock_settings):
+@patch("app.email.httpx.post")
+def test_send_invitation_api_failure(mock_post, mock_settings):
     settings = MagicMock()
-    settings.smtp_host = "smtp.test.com"
-    settings.smtp_port = 587
-    settings.smtp_user = ""
-    settings.smtp_from_email = "noreply@test.com"
-    settings.smtp_from_name = "TestApp"
-    settings.smtp_use_tls = True
-    settings.app_url = "http://localhost:3000"
+    settings.resend_api_key = "re_test_key"
+    settings.email_from_address = "noreply@test.com"
+    settings.email_from_name = "TestApp"
+    settings.app_url = "https://app.example.com"
     mock_settings.return_value = settings
 
-    mock_smtp_cls.side_effect = ConnectionRefusedError("SMTP down")
+    mock_response = MagicMock()
+    mock_response.status_code = 422
+    mock_response.text = "Validation error"
+    mock_post.return_value = mock_response
 
     result = send_invitation_email(
         to_email="partner@test.com",
@@ -87,20 +110,40 @@ def test_send_invitation_smtp_failure(mock_smtp_cls, mock_settings):
 
 
 @patch("app.email.get_settings")
-@patch("app.email.smtplib.SMTP")
-def test_invitation_email_contains_inviter_info(mock_smtp_cls, mock_settings):
+@patch("app.email.httpx.post")
+def test_send_invitation_network_error(mock_post, mock_settings):
     settings = MagicMock()
-    settings.smtp_host = "smtp.test.com"
-    settings.smtp_port = 587
-    settings.smtp_user = ""
-    settings.smtp_from_email = "noreply@test.com"
-    settings.smtp_from_name = "TestApp"
-    settings.smtp_use_tls = True
-    settings.app_url = "http://localhost:3000"
+    settings.resend_api_key = "re_test_key"
+    settings.email_from_address = "noreply@test.com"
+    settings.email_from_name = "TestApp"
+    settings.app_url = "https://app.example.com"
     mock_settings.return_value = settings
 
-    mock_server = MagicMock()
-    mock_smtp_cls.return_value = mock_server
+    mock_post.side_effect = ConnectionError("Network unreachable")
+
+    result = send_invitation_email(
+        to_email="partner@test.com",
+        inviter_name="Alice",
+        inviter_email="alice@test.com",
+        household_name="Our Home",
+    )
+    assert result is False
+
+
+@patch("app.email.get_settings")
+@patch("app.email.httpx.post")
+def test_invitation_email_contains_inviter_info(mock_post, mock_settings):
+    settings = MagicMock()
+    settings.resend_api_key = "re_test_key"
+    settings.email_from_address = "noreply@test.com"
+    settings.email_from_name = "TestApp"
+    settings.app_url = "https://app.example.com"
+    mock_settings.return_value = settings
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "msg_123"}
+    mock_post.return_value = mock_response
 
     send_invitation_email(
         to_email="bob@test.com",
@@ -109,42 +152,88 @@ def test_invitation_email_contains_inviter_info(mock_smtp_cls, mock_settings):
         household_name="The Johnsons",
     )
 
-    sent_raw = mock_server.sendmail.call_args[0][2]
-    assert "Alice Johnson invited you to join The Johnsons" in sent_raw
-
-    import base64, re
-    b64_match = re.search(r"\n\n([A-Za-z0-9+/=\n]+)\n\n--", sent_raw)
-    html = base64.b64decode(b64_match.group(1)).decode()
-    assert "Alice Johnson" in html
-    assert "The Johnsons" in html
-    assert "http://localhost:3000" in html
+    payload = mock_post.call_args[1]["json"]
+    assert "Alice Johnson" in payload["html"]
+    assert "The Johnsons" in payload["html"]
+    assert "alice@test.com" in payload["html"]
+    assert "Alice Johnson invited you to join The Johnsons" in payload["subject"]
 
 
 @patch("app.email.get_settings")
-@patch("app.email.smtplib.SMTP_SSL")
-def test_send_invitation_uses_smtp_ssl_on_port_465(mock_smtp_ssl_cls, mock_settings):
+@patch("app.email.httpx.post")
+def test_send_invitation_passes_bearer_token(mock_post, mock_settings):
     settings = MagicMock()
-    settings.smtp_host = "smtp.resend.com"
-    settings.smtp_port = 465
-    settings.smtp_user = "resend"
-    settings.smtp_password = "re_test_key"
-    settings.smtp_from_email = "noreply@example.com"
-    settings.smtp_from_name = "Fino"
-    settings.smtp_use_tls = True
-    settings.app_url = "http://localhost:3000"
+    settings.resend_api_key = "re_my_secret_key"
+    settings.email_from_address = "noreply@test.com"
+    settings.email_from_name = "TestApp"
+    settings.app_url = "https://app.example.com"
     mock_settings.return_value = settings
 
-    mock_server = MagicMock()
-    mock_smtp_ssl_cls.return_value = mock_server
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "msg_123"}
+    mock_post.return_value = mock_response
 
-    result = send_invitation_email(
+    send_invitation_email(
         to_email="partner@test.com",
         inviter_name="Alice",
         inviter_email="alice@test.com",
         household_name="Our Home",
     )
+
+    headers = mock_post.call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer re_my_secret_key"
+
+
+@patch("app.email.get_settings")
+@patch("app.email.httpx.post")
+def test_send_statement_reminder_success(mock_post, mock_settings):
+    settings = MagicMock()
+    settings.resend_api_key = "re_test_key"
+    settings.email_from_address = "noreply@test.com"
+    settings.email_from_name = "TestApp"
+    settings.app_url = "https://app.example.com"
+    mock_settings.return_value = settings
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "msg_456"}
+    mock_post.return_value = mock_response
+
+    result = send_statement_reminder_email(
+        to_email="user@test.com",
+        account_name="Chase Checking",
+    )
     assert result is True
-    mock_smtp_ssl_cls.assert_called_once_with("smtp.resend.com", 465, timeout=10)
-    mock_server.login.assert_called_once_with("resend", "re_test_key")
-    mock_server.sendmail.assert_called_once()
-    mock_server.quit.assert_called_once()
+
+    payload = mock_post.call_args[1]["json"]
+    assert payload["to"] == ["user@test.com"]
+    assert "Chase Checking" in payload["subject"]
+    assert "Chase Checking" in payload["html"]
+    assert "https://app.example.com" in payload["html"]
+
+
+@patch("app.email.get_settings")
+@patch("app.email.httpx.post")
+def test_send_statement_reminder_custom_app_url(mock_post, mock_settings):
+    settings = MagicMock()
+    settings.resend_api_key = "re_test_key"
+    settings.email_from_address = "noreply@test.com"
+    settings.email_from_name = "TestApp"
+    settings.app_url = "https://app.example.com"
+    mock_settings.return_value = settings
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "msg_456"}
+    mock_post.return_value = mock_response
+
+    result = send_statement_reminder_email(
+        to_email="user@test.com",
+        account_name="Chase Checking",
+        app_url="https://custom.example.com",
+    )
+    assert result is True
+
+    payload = mock_post.call_args[1]["json"]
+    assert "https://custom.example.com" in payload["html"]


### PR DESCRIPTION
## Summary

- **Problem:** SMTP connections to `smtp.resend.com:465` were timing out inside Docker — the hosting provider blocks outbound SMTP ports.
- **Fix:** Replace `smtplib` with a single `httpx.post` call to Resend's HTTP API (`https://api.resend.com/emails`), which uses standard HTTPS (port 443) and avoids port-blocking entirely.
- **Config simplified:** 7 `SMTP_*` env vars replaced by 3: `RESEND_API_KEY`, `EMAIL_FROM_ADDRESS`, `EMAIL_FROM_NAME`.

## Changes

| File | What changed |
|------|-------------|
| `app/email.py` | Replaced smtplib with httpx POST to Resend API |
| `app/config.py` | Replaced 7 SMTP settings with 3 Resend settings |
| `.env.example` | Updated env var names and comments |
| `tests/test_email.py` | Expanded from 6 → 11 tests (100% coverage on email.py) |
| `README.md` | Updated env vars table, test counts, coverage snapshot |

## Test plan

- [x] All 374 backend tests pass (85% coverage)
- [x] All 406 frontend tests pass
- [x] `email.py` has 100% test coverage
- [ ] Deploy and verify partner invite email sends successfully
- [ ] Update deployed `.env` with new var names (`RESEND_API_KEY`, `EMAIL_FROM_ADDRESS`, `EMAIL_FROM_NAME`)
- [ ] Update `APP_URL` to production URL in deployed `.env`


Made with [Cursor](https://cursor.com)