### PR TITLE
chore: add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .env.*
 !.env.example
+.DS_Store
 .cursor/*
 !.cursor/rules/
 Users/


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` to prevent macOS Finder metadata files from being tracked

## Test plan
- No code changes, config-only

Made with [Cursor](https://cursor.com)