### PR TITLE
release: promote staging to production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .env.*
 !.env.example
+.DS_Store
 .cursor/*
 !.cursor/rules/
 Users/


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` to prevent macOS Finder metadata from being tracked

## Test plan
- Config-only change, verified on staging

Made with [Cursor](https://cursor.com)