### PR TITLE
chore: configure Dependabot to target staging branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: pip
     directory: /
+    target-branch: staging
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -10,6 +11,7 @@ updates:
 
   - package-ecosystem: npm
     directory: /frontend
+    target-branch: staging
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -18,6 +20,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: staging
     schedule:
       interval: weekly
     open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary
- Adds `target-branch: staging` to all three Dependabot ecosystem configs (pip, npm, github-actions)
- Future dependency update PRs will target `staging` instead of `main`, aligning with the branch workflow

## Test plan
- [ ] Verify next Dependabot PR targets staging

Made with [Cursor](https://cursor.com)