### PR TITLE
chore: run CI on staging PRs instead of main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+    branches: [staging]
 
 jobs:
   backend:


### PR DESCRIPTION
## Summary
- Changes CI trigger from `pull_request`/`push` on `main` to `pull_request` on `staging`
- Tests now gate entry into staging (where real changes land) rather than the staging→main promotion
- Removes redundant `push` trigger on `main`

## Test plan
- [ ] Open a test PR targeting staging and verify CI runs
- [ ] Open a PR from staging→main and verify CI does not run

Made with [Cursor](https://cursor.com)