### PR TITLE
chore: run plaid_mode migration on startup and document ADMIN_EMAIL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ EMAIL_FROM_NAME=FinanceApp
 # APP_URL is used in email CTAs — set to your public-facing URL in production
 APP_URL=http://localhost:3000
 
+# Admin — set to the email of the instance administrator.
+# This user gets access to the Admin section in Settings (e.g. managed Plaid config).
+# Leave empty if not needed (all users default to BYOK).
+ADMIN_EMAIL=
+
 # App
 DEBUG=false
 RUN_SCHEDULER=true

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ async def lifespan(app: FastAPI):
     _migrate_llm_fields_to_household()
     _migrate_sync_fields_to_household()
     _backfill_orphan_households()
+    _migrate_household_plaid_mode()
     settings = get_settings()
     if settings.run_scheduler:
         start_scheduler()
@@ -130,6 +131,21 @@ def _backfill_orphan_households() -> None:
             session.add(HouseholdMember(household_id=hh.id, user_id=user.id, role="owner"))
         session.commit()
         logger.info("Backfill complete")
+
+
+def _migrate_household_plaid_mode() -> None:
+    """Add plaid_mode column to households and backfill existing rows to 'byok'."""
+    import logging
+
+    logger = logging.getLogger(__name__)
+    with engine.connect() as conn:
+        try:
+            conn.execute(text("ALTER TABLE households ADD COLUMN IF NOT EXISTS plaid_mode varchar"))
+        except Exception:
+            pass
+        conn.execute(text("UPDATE households SET plaid_mode = 'byok' WHERE plaid_mode IS NULL"))
+        conn.commit()
+    logger.info("Household plaid_mode migration check complete")
 
 
 def _validate_startup_settings() -> None:


### PR DESCRIPTION
## Summary

- Add `_migrate_household_plaid_mode()` to app startup so the `ALTER TABLE households ADD COLUMN plaid_mode` and backfill (`UPDATE ... SET plaid_mode = 'byok'`) run automatically on deploy — no manual SQL needed
- Add `ADMIN_EMAIL` to `.env.example` with documentation

## Test plan

- [x] Backend: 416 tests pass
- [ ] Verify migration runs on staging startup (check logs for "plaid_mode migration check complete")


Made with [Cursor](https://cursor.com)