### PR TITLE
fix: include all tables with created_at in timestamp migration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -191,15 +191,17 @@ def _migrate_timestamps() -> None:
     logger = logging.getLogger(__name__)
 
     created_at_tables = [
-        "plaid_items", "accounts", "transactions", "categories",
+        "users", "plaid_items", "accounts", "transactions", "categories",
         "category_rules", "user_settings", "budgets", "spending_preferences",
-        "goal_account_links", "net_worth_snapshots", "account_balance_snapshots",
-        "tags", "transaction_tags", "household_plaid_configs", "app_plaid_config",
+        "goals", "goal_account_links", "goal_contributions",
+        "net_worth_snapshots", "account_balance_snapshots",
+        "tags", "transaction_tags", "households", "household_plaid_configs",
+        "household_invitations", "app_plaid_config",
         "household_llm_configs", "app_llm_config", "household_sync_configs",
+        "activity_log", "error_log",
     ]
     updated_at_tables = created_at_tables + [
-        "users", "goals", "goal_contributions", "households",
-        "household_invitations", "household_members", "activity_log", "error_log",
+        "household_members",
     ]
 
     with engine.connect() as conn:


### PR DESCRIPTION
## Summary
- Moves 7 tables (`users`, `goals`, `goal_contributions`, `households`, `household_invitations`, `activity_log`, `error_log`) into `created_at_tables` in `_migrate_timestamps()`
- These models all define `created_at` but the migration only added `updated_at` for them, causing `UndefinedColumn: column users.created_at does not exist` on staging
- `household_members` remains in `updated_at`-only since it uses `joined_at` instead of `created_at`

## Test plan
- [ ] Deploy to staging and verify app starts without errors
- [ ] Verify `\d users` shows both `created_at` and `updated_at` columns
- [ ] Verify login and all pages load correctly

Made with [Cursor](https://cursor.com)