### PR TITLE
fix: allow Railway internal hosts in LLM SSRF allowlist

### DIFF
--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -71,7 +71,7 @@ def _validate_llm_base_url(url: str) -> None:
         raise HTTPException(status_code=400, detail="Invalid LLM base URL")
     if host in _ALLOWED_LLM_HOSTS:
         return
-    if host.endswith(".openai.com") or host.endswith(".anthropic.com"):
+    if host.endswith(".openai.com") or host.endswith(".anthropic.com") or host.endswith(".railway.internal"):
         return
     raise HTTPException(
         status_code=400,

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -137,6 +137,17 @@ def test_put_llm_config_ssrf_base_url_rejected(auth_client, session):
     assert resp.status_code == 400
 
 
+def test_put_llm_config_railway_internal_accepted(auth_client, session):
+    client, user = auth_client
+    make_household(session, user)
+    resp = client.put("/api/v1/settings/llm-config", json={
+        "llm_base_url": "http://ollama.railway.internal:11434/v1",
+        "llm_api_key": "test",
+        "llm_model": "llama3",
+    })
+    assert resp.status_code == 200
+
+
 # -- DELETE ----------------------------------------------------------------
 
 def test_delete_llm_config(auth_client, session):


### PR DESCRIPTION
## Summary

- Add `*.railway.internal` suffix to the LLM base URL SSRF validation, allowing Ollama and other services on Railway's private network to be used as LLM providers
- Fixes error: `LLM host 'ollama.railway.internal' is not allowed`

## Test plan

- [x] New test: `test_put_llm_config_railway_internal_accepted` verifies `http://ollama.railway.internal:11434/v1` is accepted (200)
- [x] Existing SSRF rejection test still passes (`evil.example.com` → 400)
- [x] Full backend suite: 502 passed


Made with [Cursor](https://cursor.com)