### PR TITLE
feat: batch auto-categorization with configurable batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ A self-hosted personal finance platform that aggregates bank accounts via Plaid,
 
 ### Hybrid Categorization
 1. **Rule-based** -- user-defined keyword-to-category mappings checked first
-2. **LLM fallback** -- uncategorized transactions are sent one-at-a-time to an OpenAI-compatible model for classification; per-transaction calls are resilient (individual failures don't block others)
-3. **Inline categorization** -- each transaction is categorized at import time (rules first, then per-transaction LLM fallback) with real-time streaming progress via NDJSON
-4. **Streaming auto-categorize** -- the manual auto-categorize endpoint streams NDJSON progress events, showing per-transaction categorization status with a progress bar on the frontend
+2. **Batched LLM fallback** -- uncategorized transactions are batched into configurable chunks (default 10, range 1–50) and sent to an OpenAI-compatible model; reduces API calls and avoids rate limiting
+3. **Inline categorization** -- each transaction is categorized at import time (rules first, then batched LLM fallback) with real-time streaming progress via NDJSON
+4. **Streaming auto-categorize** -- the manual auto-categorize endpoint batches LLM calls but streams per-transaction NDJSON progress events, showing categorization status with a progress bar on the frontend
 5. Auto-categorization also runs on every Plaid sync and can be triggered manually for any remaining uncategorized transactions
 
 ### Tags
@@ -192,7 +192,7 @@ A self-hosted personal finance platform that aggregates bank accounts via Plaid,
 - **Profile & Account** -- display name, avatar URL, bio (with Google fallback)
 - **General** -- currency (CAD, USD, EUR, GBP, etc.), date format, number locale; "Settings saved" flash on save
 - **Sync Schedule** -- per-household sync config (enable/disable, hour, minute, timezone); owner-only editing; "Schedule saved" flash on save; each household gets its own cron job on its own schedule
-- **AI Categorization** — mode-aware: shows "Using managed AI" badge with switch button when managed, or BYOK config form (base URL, model, API key) with switch-to-managed button when BYOK; switchable between managed/BYOK at any time
+- **AI Categorization** — mode-aware: shows "Using managed AI" badge with switch button when managed, or BYOK config form (base URL, model, API key, transactions per request) with switch-to-managed button when BYOK; switchable between managed/BYOK at any time
 - **Integrations** -- household owner configures Plaid client ID, secret, and environment (sandbox/development/production); credentials encrypted at rest with Fernet; masked last-4 display for verification; auto-scrolls via `?section=integrations` deep link
 - **Data Management** -- CSV export, Bulk Import Accounts & Transactions, Bulk Import Accounts & Balances, bulk delete, factory reset (wipes all financial data while preserving login and household), delete account (permanently removes user and all data with household cleanup)
 - Category rules management is on the dedicated Categories page
@@ -641,7 +641,7 @@ python3 -m pytest -v              # verbose output
 python3 -m pytest tests/test_auth.py  # run a single file
 ```
 
-**What's tested (492 tests across 23 files):**
+**What's tested (509 tests across 23 files):**
 
 | File | Tests | Coverage |
 |------|-------|----------|
@@ -649,7 +649,7 @@ python3 -m pytest tests/test_auth.py  # run a single file
 | `test_goals` | 34 | CRUD, shared goals, linked accounts, contributions, ownership, date validation |
 | `test_budgets` | 32 | CRUD, copy, summary, shared budgets, spending preferences, conflicts |
 | `test_household` | 37 | Invite, accept, decline, cancel, rename, leave, scope, invitation email, leave cleanup (budgets, goals, preferences, invitations), accept dissolves solo household (with/without Plaid/LLM/Sync config), blocked when partnered, Plaid items warning |
-| `test_transactions` | 30 | CRUD, search, account/source/category filters, pagination, manual vs. Plaid, auto-categorize (rules, per-txn LLM, partial failure, NDJSON streaming), recurring, date validation, response schema |
+| `test_transactions` | 31 | CRUD, search, account/source/category filters, pagination, manual vs. Plaid, auto-categorize (rules, batched LLM, batch_size control, partial failure with break, NDJSON streaming with batched LLM), recurring, date validation, response schema |
 | `test_categories` | 27 | Full CRUD, auto-seed defaults, create validation (empty/whitespace/duplicate), rename cascades to transactions and rules, delete with reassign or nullify, cross-user isolation |
 | `test_accounts` | 35 | List, update, unlink, summary, manual create/delete, unlinked Plaid delete, balance update (manual-only restriction), CSV import, cascade delete, negative amounts, inline auto-categorization, statement_available_day (create/update/clear/validate), statement-reminders endpoint (match/no-match/last-day-fallback/auth) |
 | `test_scheduler` | 11 | Statement reminder scheduler job (day match, de-duplication, last-day-of-month fallback, no-accounts), per-household scheduler (reads DB config, no-config skips, disabled skips, multiple households, scoped sync items, scoped reminders) |
@@ -659,11 +659,11 @@ python3 -m pytest tests/test_auth.py  # run a single file
 | `test_reports` | 8 | Spending by category, monthly trends, top merchants |
 | `test_email` | 11 | Resend HTTP API, invitation + statement reminder templates, send/skip/fail/network-error handling, bearer auth, app_url in CTAs |
 | `test_plaid_config` | 13 | GET (configured/not/no-household/member-read), PUT (create/update/non-owner/no-household/invalid-env), DELETE (success/non-owner/not-configured/no-household) |
-| `test_llm_config` | — | BYO LLM config CRUD (owner-only, encryption) |
+| `test_llm_config` | 20 | BYO LLM config CRUD (owner-only, encryption, batch_size default/custom/validation), SSRF validation, Railway internal URL |
 | `test_auth` | 8 | Google OAuth login (mocked), session, `/me`, logout, auto-household on signup, no duplicate household on re-login |
 | `test_managed_plaid` | 16 | PlaidMode enum, AppPlaidConfig model, Household.plaid_mode field, plaid client resolution (managed vs BYOK: uses correct credentials, raises when disabled/missing/none) |
 | `test_managed_plaid_routes` | 26 | Plaid mode GET/PUT (managed/byok/none/switch-blocked/validation), admin plaid-config CRUD (admin-only guard, create/update/delete, household count), /auth/me is_admin field |
-| `test_managed_llm_routes` | 32 | LLM mode GET/PUT (managed/byok/none/switchable/validation), admin llm-config CRUD (admin-only guard, create/update/delete, unchanged sentinel, SSRF validation, household count), categorizer resolution (managed uses AppLLMConfig, BYOK uses HouseholdLLMConfig, none/null returns empty, disabled returns empty) |
+| `test_managed_llm_routes` | 35 | LLM mode GET/PUT (managed/byok/none/switchable/validation), admin llm-config CRUD (admin-only guard, create/update/delete, unchanged sentinel, SSRF validation, household count, batch_size create/validation), categorizer resolution (managed uses AppLLMConfig with batch_size, BYOK uses HouseholdLLMConfig with batch_size, none/null returns empty, disabled returns empty) |
 | `test_admin` | 44 | Admin guard (403 on all endpoints), overview aggregates, users list (pagination, search, stats, filters: active_days/has_linked/has_manual/sort), user detail (accounts, transactions, activity, stats, 404, auth guard), user update (promote/demote/disable/enable), user delete (full FK cascade, self-deletion blocked), disabled user auth, plaid health, error log (pagination, filters), analytics (active users, feature adoption, transaction volume, storage), activity logging, timestamps (created_at on insert, updated_at on flush, created_at unchanged on update) |
 | `test_net_worth` | 5 | Snapshots, history |
 | `test_health` | 2 | Liveness and readiness endpoints |
@@ -687,7 +687,7 @@ npm run test:watch                # watch mode
 npx vitest run tests/sidebar.test.tsx  # run a single file
 ```
 
-**What's tested (464 tests across 44 files):**
+**What's tested (466 tests across 44 files):**
 
 | File | Tests | Coverage |
 |------|-------|----------|
@@ -744,7 +744,7 @@ npx vitest run tests/sidebar.test.tsx  # run a single file
 
 ### Latest coverage snapshot
 
-- Backend (`pytest --cov=app --cov-report=term`): **87% total** (`4119` statements, `552` missed)
+- Backend (`pytest --cov=app --cov-report=term`): **86% total** (`4214` statements, `595` missed)
 - Frontend (`npx vitest run --coverage`): **76.28% statements**, **71.95% branches**, **61.95% functions**, **77.19% lines**
 
 ## Environment Variables

--- a/app/categorizer.py
+++ b/app/categorizer.py
@@ -96,26 +96,27 @@ def categorize_by_llm(transaction: Transaction, user_id: int) -> str | None:
 _last_llm_error: str | None = None
 
 
-def _get_llm_config(user_id: int) -> tuple[str, str, str]:
-    """Return (base_url, api_key, model) based on household's llm_mode."""
+def _get_llm_config(user_id: int) -> tuple[str, str, str, int]:
+    """Return (base_url, api_key, model, batch_size) based on household's llm_mode."""
     global _last_llm_error
+    _empty = ("", "", "", 10)
     try:
         with Session(engine) as session:
             member = session.exec(
                 select(HouseholdMember).where(HouseholdMember.user_id == user_id)
             ).first()
             if not member:
-                return ("", "", "")
+                return _empty
 
             household = session.get(Household, member.household_id)
             if not household:
-                return ("", "", "")
+                return _empty
 
             if household.llm_mode == LLMMode.MANAGED:
                 app_config = session.exec(select(AppLLMConfig)).first()
                 if not app_config or not app_config.enabled or not app_config.encrypted_api_key:
-                    return ("", "", "")
-                return (app_config.llm_base_url, decrypt_token(app_config.encrypted_api_key), app_config.llm_model)
+                    return _empty
+                return (app_config.llm_base_url, decrypt_token(app_config.encrypted_api_key), app_config.llm_model, app_config.batch_size)
 
             if household.llm_mode == LLMMode.BYOK:
                 config = session.exec(
@@ -124,17 +125,14 @@ def _get_llm_config(user_id: int) -> tuple[str, str, str]:
                     )
                 ).first()
                 if not config or not config.encrypted_api_key:
-                    return ("", "", "")
-                return (config.llm_base_url, decrypt_token(config.encrypted_api_key), config.llm_model)
+                    return _empty
+                return (config.llm_base_url, decrypt_token(config.encrypted_api_key), config.llm_model, config.batch_size)
 
-            return ("", "", "")
+            return _empty
     except Exception as exc:
         _last_llm_error = f"Config lookup failed: {type(exc).__name__}: {exc}"
         logger.exception("_get_llm_config failed for user %s", user_id)
-        return ("", "", "")
-
-
-_LLM_BATCH_SIZE = 25
+        return _empty
 
 
 def _categorize_chunk_llm(
@@ -190,8 +188,8 @@ def _categorize_chunk_llm(
 
 
 def categorize_batch_llm(transactions: list[Transaction], user_id: int) -> dict[int, str]:
-    """Send transactions to the LLM in chunks of _LLM_BATCH_SIZE and return {id: category}."""
-    base_url, api_key, model = _get_llm_config(user_id)
+    """Send transactions to the LLM in chunks using configured batch_size."""
+    base_url, api_key, model, batch_size = _get_llm_config(user_id)
     if not api_key:
         logger.warning("LLM API key not configured — skipping LLM categorization")
         return {}
@@ -210,8 +208,8 @@ def categorize_batch_llm(transactions: list[Transaction], user_id: int) -> dict[
         return {}
 
     all_results: dict[int, str] = {}
-    for i in range(0, len(txn_list), _LLM_BATCH_SIZE):
-        chunk = txn_list[i : i + _LLM_BATCH_SIZE]
+    for i in range(0, len(txn_list), batch_size):
+        chunk = txn_list[i : i + batch_size]
         try:
             chunk_results = _categorize_chunk_llm(chunk, base_url, api_key, model)
             all_results.update(chunk_results)
@@ -227,7 +225,7 @@ def categorize_batch_llm(transactions: list[Transaction], user_id: int) -> dict[
 def categorize_single_llm(transaction: Transaction, user_id: int) -> str | None:
     """Categorize one transaction via LLM. Returns category or None on failure."""
     global _last_llm_error
-    base_url, api_key, model = _get_llm_config(user_id)
+    base_url, api_key, model, _batch = _get_llm_config(user_id)
     if not api_key:
         _last_llm_error = "LLM API key not configured"
         return None
@@ -282,14 +280,50 @@ def auto_categorize_pending(session: Session, user_id: int) -> dict:
         return {"total": 0, "categorized": 0, "skipped": 0}
 
     categorized = 0
+    llm_pending: list[Transaction] = []
+
     for txn in txns:
         cat = categorize_by_rules(txn.merchant_name or "", session, user_id)
-        if not cat:
-            cat = categorize_single_llm(txn, user_id)
         if cat:
             txn.category = cat
             session.add(txn)
             categorized += 1
+        else:
+            llm_pending.append(txn)
+
+    if llm_pending:
+        base_url, api_key, model, batch_size = _get_llm_config(user_id)
+        if api_key:
+            txn_dicts = [
+                {
+                    "id": t.id,
+                    "merchant_name": t.merchant_name or "Unknown",
+                    "plaid_category": getattr(t, "plaid_category_code", None) or "N/A",
+                    "amount": float(t.amount),
+                }
+                for t in llm_pending
+            ]
+            txn_by_id = {t.id: t for t in llm_pending}
+
+            for i in range(0, len(txn_dicts), batch_size):
+                chunk = txn_dicts[i : i + batch_size]
+                try:
+                    results = _categorize_chunk_llm(chunk, base_url, api_key, model)
+                    for tid, cat in results.items():
+                        txn_obj = txn_by_id.get(tid)
+                        if txn_obj:
+                            txn_obj.category = cat
+                            session.add(txn_obj)
+                            categorized += 1
+                except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                    _last_llm_error = f"LLM unreachable at {base_url}: {type(exc).__name__}: {exc}"
+                    logger.warning("LLM unreachable (batch %d–%d): %s", i, i + len(chunk), exc)
+                    break
+                except Exception as exc:
+                    _last_llm_error = f"LLM error: {type(exc).__name__}: {exc}"
+                    logger.exception("LLM categorization failed for batch %d–%d", i, i + len(chunk))
+        else:
+            _last_llm_error = "LLM API key not configured"
 
     session.commit()
 

--- a/app/models.py
+++ b/app/models.py
@@ -403,6 +403,7 @@ class HouseholdLLMConfig(SQLModel, table=True):
     llm_base_url: str = Field(default="https://api.openai.com/v1")
     encrypted_api_key: str
     llm_model: str = Field(default="gpt-4o-mini")
+    batch_size: int = Field(default=10)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: Optional[datetime] = Field(default=None)
 
@@ -417,6 +418,7 @@ class AppLLMConfig(SQLModel, table=True):
     encrypted_api_key: str
     llm_model: str = Field(default="gpt-4o-mini")
     enabled: bool = Field(default=False)
+    batch_size: int = Field(default=10)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: Optional[datetime] = Field(default=None)
 

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import sqlalchemy as sa
 from sqlalchemy import delete as sa_delete
 from sqlmodel import Session, or_, select
@@ -497,17 +497,19 @@ class LLMConfigUpdate(BaseModel):
     llm_base_url: str
     llm_api_key: str
     llm_model: str
+    batch_size: int = Field(default=10, ge=1, le=50)
 
 
 def _llm_config_response(config: Optional[HouseholdLLMConfig]) -> dict:
     if not config:
-        return {"configured": False, "llm_base_url": None, "llm_model": None, "api_key_last4": None}
+        return {"configured": False, "llm_base_url": None, "llm_model": None, "api_key_last4": None, "batch_size": 10}
     api_key = decrypt_token(config.encrypted_api_key)
     return {
         "configured": True,
         "llm_base_url": config.llm_base_url,
         "llm_model": config.llm_model,
         "api_key_last4": api_key[-4:] if len(api_key) >= 4 else api_key,
+        "batch_size": config.batch_size,
     }
 
 
@@ -556,12 +558,14 @@ def update_llm_config(
         config.llm_base_url = body.llm_base_url
         config.encrypted_api_key = encrypt_token(body.llm_api_key)
         config.llm_model = body.llm_model
+        config.batch_size = body.batch_size
     else:
         config = HouseholdLLMConfig(
             household_id=member.household_id,
             llm_base_url=body.llm_base_url,
             encrypted_api_key=encrypt_token(body.llm_api_key),
             llm_model=body.llm_model,
+            batch_size=body.batch_size,
         )
 
     session.add(config)
@@ -1792,6 +1796,7 @@ class AdminLLMConfigUpdate(BaseModel):
     llm_api_key: str
     llm_model: str
     enabled: bool
+    batch_size: int = Field(default=10, ge=1, le=50)
 
 
 @router.get("/admin/llm-config")
@@ -1815,6 +1820,7 @@ def get_admin_llm_config(
             "llm_base_url": None,
             "llm_model": None,
             "api_key_last4": None,
+            "batch_size": 10,
             "managed_household_count": managed_count,
         }
 
@@ -1825,6 +1831,7 @@ def get_admin_llm_config(
         "llm_base_url": config.llm_base_url,
         "llm_model": config.llm_model,
         "api_key_last4": api_key[-4:] if len(api_key) >= 4 else api_key,
+        "batch_size": config.batch_size,
         "managed_household_count": managed_count,
     }
 
@@ -1847,6 +1854,7 @@ def update_admin_llm_config(
         config.llm_base_url = body.llm_base_url
         config.llm_model = body.llm_model
         config.enabled = body.enabled
+        config.batch_size = body.batch_size
     else:
         if body.llm_api_key == _SENTINEL:
             raise HTTPException(status_code=400, detail="API key is required for initial setup")
@@ -1855,6 +1863,7 @@ def update_admin_llm_config(
             encrypted_api_key=encrypt_token(body.llm_api_key),
             llm_model=body.llm_model,
             enabled=body.enabled,
+            batch_size=body.batch_size,
         )
 
     session.add(config)
@@ -1868,6 +1877,7 @@ def update_admin_llm_config(
         "llm_base_url": config.llm_base_url,
         "llm_model": config.llm_model,
         "api_key_last4": api_key[-4:] if len(api_key) >= 4 else api_key,
+        "batch_size": config.batch_size,
     }
 
 

--- a/app/routes/transactions.py
+++ b/app/routes/transactions.py
@@ -18,6 +18,8 @@ from sqlmodel import Session, or_, select
 
 from app.auth import get_current_user
 from app.categorizer import (
+    _categorize_chunk_llm,
+    _get_llm_config,
     auto_categorize_pending,
     categorize_by_rules,
     categorize_single_llm,
@@ -271,7 +273,14 @@ def auto_categorize(
 
 
 def _auto_categorize_stream(session: Session, user: User):
-    """Stream per-transaction categorization progress as NDJSON."""
+    """Stream per-transaction categorization progress as NDJSON.
+
+    Batches LLM calls using the configured batch_size but yields
+    individual progress events per transaction.
+    """
+    import logging as _logging
+    _logger = _logging.getLogger(__name__)
+
     user_account_ids = session.exec(
         select(Account.id).where(Account.user_id == user.id)
     ).all()
@@ -287,25 +296,94 @@ def _auto_categorize_stream(session: Session, user: User):
 
     total = len(txns)
     categorized = 0
+    progress_idx = 0
+    llm_pending: list[Transaction] = []
 
-    for idx, txn in enumerate(txns, 1):
+    for txn in txns:
         cat = categorize_by_rules(txn.merchant_name or "", session, user.id)
-        if not cat:
-            cat = categorize_single_llm(txn, user.id)
-        status = "skipped"
         if cat:
             txn.category = cat
             session.add(txn)
             categorized += 1
-            status = "categorized"
+            progress_idx += 1
+            yield json.dumps({
+                "status": "categorized",
+                "current": progress_idx,
+                "total": total,
+                "merchant_name": txn.merchant_name,
+                "category": cat,
+            }) + "\n"
+        else:
+            llm_pending.append(txn)
 
-        yield json.dumps({
-            "status": status,
-            "current": idx,
-            "total": total,
-            "merchant_name": txn.merchant_name,
-            "category": cat,
-        }) + "\n"
+    if llm_pending:
+        import httpx as _httpx
+        base_url, api_key, model, batch_size = _get_llm_config(user.id)
+        if api_key:
+            txn_dicts = [
+                {
+                    "id": t.id,
+                    "merchant_name": t.merchant_name or "Unknown",
+                    "plaid_category": getattr(t, "plaid_category_code", None) or "N/A",
+                    "amount": float(t.amount),
+                }
+                for t in llm_pending
+            ]
+            txn_by_id = {t.id: t for t in llm_pending}
+
+            for i in range(0, len(txn_dicts), batch_size):
+                chunk = txn_dicts[i : i + batch_size]
+                chunk_txns = llm_pending[i : i + batch_size]
+                try:
+                    results = _categorize_chunk_llm(chunk, base_url, api_key, model)
+                except (_httpx.TimeoutException, _httpx.ConnectError) as exc:
+                    _logger.warning("LLM unreachable (batch %d–%d): %s", i, i + len(chunk), exc)
+                    for txn in chunk_txns:
+                        progress_idx += 1
+                        yield json.dumps({
+                            "status": "skipped",
+                            "current": progress_idx,
+                            "total": total,
+                            "merchant_name": txn.merchant_name,
+                            "category": None,
+                        }) + "\n"
+                    break
+                except Exception:
+                    _logger.exception("LLM categorization failed (batch %d–%d)", i, i + len(chunk))
+                    results = {}
+
+                for txn in chunk_txns:
+                    cat = results.get(txn.id)
+                    progress_idx += 1
+                    if cat:
+                        txn.category = cat
+                        session.add(txn)
+                        categorized += 1
+                        yield json.dumps({
+                            "status": "categorized",
+                            "current": progress_idx,
+                            "total": total,
+                            "merchant_name": txn.merchant_name,
+                            "category": cat,
+                        }) + "\n"
+                    else:
+                        yield json.dumps({
+                            "status": "skipped",
+                            "current": progress_idx,
+                            "total": total,
+                            "merchant_name": txn.merchant_name,
+                            "category": None,
+                        }) + "\n"
+        else:
+            for txn in llm_pending:
+                progress_idx += 1
+                yield json.dumps({
+                    "status": "skipped",
+                    "current": progress_idx,
+                    "total": total,
+                    "merchant_name": txn.merchant_name,
+                    "category": None,
+                }) + "\n"
 
     session.commit()
     yield json.dumps({

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -880,6 +880,7 @@ function LLMConfigTab() {
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState("");
   const [enabled, setEnabled] = useState(false);
+  const [batchSize, setBatchSize] = useState(10);
   const [showApiKey, setShowApiKey] = useState(false);
   const [saved, setSaved] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
@@ -890,6 +891,7 @@ function LLMConfigTab() {
       setBaseUrl(adminConfig.llm_base_url ?? "");
       setModel(adminConfig.llm_model ?? "");
       setEnabled(adminConfig.enabled);
+      setBatchSize(adminConfig.batch_size ?? 10);
     }
   }, [adminConfig]);
 
@@ -900,6 +902,7 @@ function LLMConfigTab() {
         llm_api_key: apiKey || "unchanged",
         llm_model: model,
         enabled,
+        batch_size: batchSize,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-llm-config"] });
@@ -917,6 +920,7 @@ function LLMConfigTab() {
         llm_api_key: "unchanged",
         llm_model: model || adminConfig?.llm_model || "",
         enabled: !enabled,
+        batch_size: batchSize,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-llm-config"] });
@@ -1015,15 +1019,32 @@ function LLMConfigTab() {
             </div>
           </div>
 
-          <div className="max-w-xs">
-            <label className={labelClass}>Model</label>
-            <input
-              type="text"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              placeholder={adminConfig.configured ? adminConfig.llm_model ?? "" : "gpt-4o-mini"}
-              className={`${inputClass} w-full`}
-            />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Model</label>
+              <input
+                type="text"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder={adminConfig.configured ? adminConfig.llm_model ?? "" : "gpt-4o-mini"}
+                className={`${inputClass} w-full`}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Transactions per request</label>
+              <input
+                type="number"
+                min={1}
+                max={50}
+                value={batchSize}
+                onChange={(e) => setBatchSize(Math.max(1, Math.min(50, parseInt(e.target.value) || 1)))}
+                className={`${inputClass} w-full`}
+                data-testid="llm-batch-size"
+              />
+              <p className="mt-0.5 text-right text-[10px] text-muted-foreground">
+                How many transactions to send in each LLM call (1–50)
+              </p>
+            </div>
           </div>
 
           {!adminConfig.configured && (

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1360,6 +1360,7 @@ function AiSection() {
   const [baseUrl, setBaseUrl] = useState("");
   const [model, setModel] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [batchSize, setBatchSize] = useState(10);
   const [showKey, setShowKey] = useState(false);
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
 
@@ -1367,12 +1368,14 @@ function AiSection() {
     if (llmConfig?.configured) {
       setBaseUrl(llmConfig.llm_base_url ?? "");
       setModel(llmConfig.llm_model ?? "");
+      setBatchSize(llmConfig.batch_size ?? 10);
     }
   }, [llmConfig]);
 
   const dirty =
     baseUrl !== (llmConfig?.llm_base_url ?? "") ||
     model !== (llmConfig?.llm_model ?? "") ||
+    batchSize !== (llmConfig?.batch_size ?? 10) ||
     apiKey.length > 0;
 
   const saveMutation = useMutation({
@@ -1400,6 +1403,7 @@ function AiSection() {
       llm_base_url: baseUrl || "https://api.openai.com/v1",
       llm_api_key: apiKey || "unchanged",
       llm_model: model || "gpt-4o-mini",
+      batch_size: batchSize,
     });
   }
 
@@ -1521,6 +1525,21 @@ function AiSection() {
                   )}
                 </button>
               </div>
+            </div>
+            <div>
+              <label className={labelClass}>Transactions per request</label>
+              <input
+                type="number"
+                min={1}
+                max={50}
+                value={batchSize}
+                onChange={(e) => setBatchSize(Math.max(1, Math.min(50, parseInt(e.target.value) || 1)))}
+                className={`${inputClass} w-full`}
+                data-testid="llm-batch-size"
+              />
+              <p className="mt-0.5 text-right text-[10px] text-muted-foreground">
+                How many transactions to send in each LLM call (1–50)
+              </p>
             </div>
           </div>
           <div className="mt-4 flex items-center justify-between">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -539,6 +539,7 @@ export const api = {
     llm_api_key: string;
     llm_model: string;
     enabled: boolean;
+    batch_size?: number;
   }) =>
     fetcher<AdminLLMConfig>("/settings/admin/llm-config", {
       method: "PUT",
@@ -560,7 +561,7 @@ export const api = {
   // LLM config (per-household BYOK)
   getLLMConfig: () => fetcher<LLMConfig>("/settings/llm-config"),
 
-  updateLLMConfig: (body: { llm_base_url: string; llm_api_key: string; llm_model: string }) =>
+  updateLLMConfig: (body: { llm_base_url: string; llm_api_key: string; llm_model: string; batch_size?: number }) =>
     fetcher<LLMConfig>("/settings/llm-config", {
       method: "PUT",
       body: JSON.stringify(body),

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -309,6 +309,7 @@ export interface LLMConfig {
   llm_base_url: string | null;
   llm_model: string | null;
   api_key_last4: string | null;
+  batch_size?: number;
 }
 
 export interface PlaidConfig {
@@ -340,6 +341,7 @@ export interface AdminLLMConfig {
   llm_base_url: string | null;
   llm_model: string | null;
   api_key_last4: string | null;
+  batch_size: number;
   managed_household_count: number;
 }
 

--- a/frontend/tests/admin.test.tsx
+++ b/frontend/tests/admin.test.tsx
@@ -134,6 +134,7 @@ const MOCK_ADMIN_LLM_CONFIG = {
   llm_base_url: "https://api.openai.com/v1",
   llm_model: "gpt-4o",
   api_key_last4: "5678",
+  batch_size: 10,
   managed_household_count: 2,
 };
 
@@ -528,5 +529,21 @@ describe("AdminPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("llm-enabled-toggle")).toBeInTheDocument();
     });
+  });
+
+  it("LLM Config tab shows 'Transactions per request' field", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AdminPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /llm config/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("tab", { name: /llm config/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("llm-batch-size")).toBeInTheDocument();
+    });
+    const input = screen.getByTestId("llm-batch-size") as HTMLInputElement;
+    expect(input.value).toBe("10");
   });
 });

--- a/frontend/tests/settings-page.test.tsx
+++ b/frontend/tests/settings-page.test.tsx
@@ -509,5 +509,23 @@ describe("SettingsPage", () => {
       });
       expect(screen.queryByRole("button", { name: /switch to managed/i })).not.toBeInTheDocument();
     });
+
+    it("shows 'Transactions per request' field in BYOK config form", async () => {
+      mockApi.getLLMMode.mockResolvedValue({ mode: "byok", managed_available: false });
+      mockApi.getLLMConfig.mockResolvedValue({
+        configured: true,
+        llm_base_url: "https://api.openai.com/v1",
+        llm_model: "gpt-4o",
+        api_key_last4: "1234",
+        batch_size: 15,
+      });
+
+      renderWithProviders(<SettingsPage />);
+
+      await waitFor(() => {
+        const input = screen.getByTestId("llm-batch-size") as HTMLInputElement;
+        expect(input.value).toBe("15");
+      });
+    });
   });
 });

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -126,6 +126,51 @@ def test_put_llm_config_no_household(auth_client):
     assert resp.status_code == 404
 
 
+def test_get_llm_config_returns_batch_size(auth_client, session):
+    client, user = auth_client
+    hh = make_household(session, user)
+    make_llm_config(session, hh)
+    resp = client.get("/api/v1/settings/llm-config")
+    assert resp.status_code == 200
+    assert resp.json()["batch_size"] == 10  # default
+
+
+def test_put_llm_config_with_batch_size(auth_client, session):
+    client, user = auth_client
+    make_household(session, user)
+    resp = client.put("/api/v1/settings/llm-config", json={
+        "llm_base_url": "https://api.openai.com/v1",
+        "llm_api_key": "sk-mykey1234",
+        "llm_model": "gpt-4o-mini",
+        "batch_size": 5,
+    })
+    assert resp.status_code == 200
+    assert resp.json()["batch_size"] == 5
+
+    config = session.exec(select(HouseholdLLMConfig)).first()
+    assert config.batch_size == 5
+
+
+def test_put_llm_config_batch_size_validation(auth_client, session):
+    client, user = auth_client
+    make_household(session, user)
+    resp = client.put("/api/v1/settings/llm-config", json={
+        "llm_base_url": "https://api.openai.com/v1",
+        "llm_api_key": "test",
+        "llm_model": "gpt-4o-mini",
+        "batch_size": 0,
+    })
+    assert resp.status_code == 422
+
+    resp = client.put("/api/v1/settings/llm-config", json={
+        "llm_base_url": "https://api.openai.com/v1",
+        "llm_api_key": "test",
+        "llm_model": "gpt-4o-mini",
+        "batch_size": 51,
+    })
+    assert resp.status_code == 422
+
+
 def test_put_llm_config_ssrf_base_url_rejected(auth_client, session):
     client, user = auth_client
     make_household(session, user)

--- a/tests/test_managed_llm_routes.py
+++ b/tests/test_managed_llm_routes.py
@@ -214,6 +214,7 @@ class TestAdminGetLLMConfig:
             assert data["llm_base_url"] == "https://api.openai.com/v1"
             assert data["llm_model"] == "gpt-4o"
             assert data["api_key_last4"] == "5678"
+            assert data["batch_size"] == 10  # default
         finally:
             _clear_admin_email()
 
@@ -324,6 +325,50 @@ class TestAdminUpdateLLMConfig:
         finally:
             _clear_admin_email()
 
+    def test_admin_creates_config_with_batch_size(self, auth_client, session):
+        client, user = auth_client
+        _set_admin_email(user.email)
+        try:
+            resp = client.put("/api/v1/settings/admin/llm-config", json={
+                "llm_base_url": "https://api.openai.com/v1",
+                "llm_api_key": "sk-batch-key-1234",
+                "llm_model": "gpt-4o",
+                "enabled": True,
+                "batch_size": 25,
+            })
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["batch_size"] == 25
+
+            db_config = session.exec(select(AppLLMConfig)).first()
+            assert db_config.batch_size == 25
+        finally:
+            _clear_admin_email()
+
+    def test_batch_size_validation(self, auth_client, session):
+        client, user = auth_client
+        _set_admin_email(user.email)
+        try:
+            resp = client.put("/api/v1/settings/admin/llm-config", json={
+                "llm_base_url": "https://api.openai.com/v1",
+                "llm_api_key": "key",
+                "llm_model": "gpt-4o",
+                "enabled": True,
+                "batch_size": 0,
+            })
+            assert resp.status_code == 422
+
+            resp = client.put("/api/v1/settings/admin/llm-config", json={
+                "llm_base_url": "https://api.openai.com/v1",
+                "llm_api_key": "key",
+                "llm_model": "gpt-4o",
+                "enabled": True,
+                "batch_size": 51,
+            })
+            assert resp.status_code == 422
+        finally:
+            _clear_admin_email()
+
     def test_ssrf_base_url_rejected(self, auth_client, session):
         client, user = auth_client
         _set_admin_email(user.email)
@@ -403,10 +448,37 @@ class TestCategorizerLLMResolution:
         from tests.conftest import _test_engine
         monkeypatch.setattr(cat_module, "engine", _test_engine)
 
-        base_url, api_key, model = cat_module._get_llm_config(user.id)
+        base_url, api_key, model, batch_size = cat_module._get_llm_config(user.id)
         assert base_url == "https://api.openai.com/v1"
         assert api_key == "app_managed_key"
         assert model == "gpt-4o"
+        assert batch_size == 10  # default
+
+    def test_managed_mode_returns_custom_batch_size(self, auth_client, session, monkeypatch):
+        """Managed config with custom batch_size propagates to _get_llm_config."""
+        client, user = auth_client
+        hh = make_household(session, user)
+        hh.llm_mode = LLMMode.MANAGED
+        session.add(hh)
+        session.commit()
+
+        cfg = make_app_llm_config(
+            session,
+            base_url="https://api.openai.com/v1",
+            api_key="managed_key",
+            model="gpt-4o",
+            enabled=True,
+        )
+        cfg.batch_size = 25
+        session.add(cfg)
+        session.commit()
+
+        import app.categorizer as cat_module
+        from tests.conftest import _test_engine
+        monkeypatch.setattr(cat_module, "engine", _test_engine)
+
+        _, _, _, batch_size = cat_module._get_llm_config(user.id)
+        assert batch_size == 25
 
     def test_byok_mode_uses_household_config(self, auth_client, session, monkeypatch):
         """When llm_mode is byok, categorizer should use HouseholdLLMConfig."""
@@ -427,10 +499,11 @@ class TestCategorizerLLMResolution:
         from tests.conftest import _test_engine
         monkeypatch.setattr(cat_module, "engine", _test_engine)
 
-        base_url, api_key, model = cat_module._get_llm_config(user.id)
+        base_url, api_key, model, batch_size = cat_module._get_llm_config(user.id)
         assert base_url == "http://localhost:11434/v1"
         assert api_key == "byok_key_here"
         assert model == "llama3"
+        assert batch_size == 10  # default
 
     def test_none_mode_returns_empty(self, auth_client, session, monkeypatch):
         """When llm_mode is none, categorizer should skip LLM."""
@@ -444,7 +517,7 @@ class TestCategorizerLLMResolution:
         from tests.conftest import _test_engine
         monkeypatch.setattr(cat_module, "engine", _test_engine)
 
-        base_url, api_key, model = cat_module._get_llm_config(user.id)
+        base_url, api_key, model, batch_size = cat_module._get_llm_config(user.id)
         assert api_key == ""
 
     def test_null_mode_returns_empty(self, auth_client, session, monkeypatch):
@@ -456,7 +529,7 @@ class TestCategorizerLLMResolution:
         from tests.conftest import _test_engine
         monkeypatch.setattr(cat_module, "engine", _test_engine)
 
-        base_url, api_key, model = cat_module._get_llm_config(user.id)
+        base_url, api_key, model, batch_size = cat_module._get_llm_config(user.id)
         assert api_key == ""
 
     def test_managed_mode_disabled_returns_empty(self, auth_client, session, monkeypatch):
@@ -473,5 +546,5 @@ class TestCategorizerLLMResolution:
         from tests.conftest import _test_engine
         monkeypatch.setattr(cat_module, "engine", _test_engine)
 
-        base_url, api_key, model = cat_module._get_llm_config(user.id)
+        base_url, api_key, model, batch_size = cat_module._get_llm_config(user.id)
         assert api_key == ""

--- a/tests/test_plaid.py
+++ b/tests/test_plaid.py
@@ -288,7 +288,7 @@ def test_sync_all_stream_success(auth_client, session):
     with patch(MOCK_HH_CLIENT, return_value=mock_client), \
          patch(MOCK_HH_CLIENT_UID, return_value=mock_client), \
          patch("app.routes.plaid.decrypt_token", return_value="access-test"), \
-         patch("app.categorizer._get_llm_config", return_value=("", "", "")):
+         patch("app.categorizer._get_llm_config", return_value=("", "", "", 10)):
         resp = client.post(
             "/api/v1/plaid/sync-all-stream",
             headers={"Accept": "application/x-ndjson"},

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -371,7 +371,7 @@ def test_import_categorizes_via_llm_fallback(auth_client, session):
         return resp
 
     with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model",
+        "http://fake-llm", "fake-key", "test-model", 10,
     )), patch("httpx.post", side_effect=fake_llm_response):
         resp = client.post(
             f"/api/v1/settings/import/{acct.id}",
@@ -408,7 +408,7 @@ def test_import_streaming_shows_llm_category(auth_client, session):
         return resp
 
     with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model",
+        "http://fake-llm", "fake-key", "test-model", 10,
     )), patch("httpx.post", side_effect=fake_llm_response):
         resp = client.post(
             f"/api/v1/settings/import/{acct.id}",
@@ -436,7 +436,7 @@ def test_import_skips_llm_when_flag_set(auth_client, session):
     acct = make_account(session, user, name="Checking")
 
     with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model",
+        "http://fake-llm", "fake-key", "test-model", 10,
     )), patch("httpx.post") as mock_post:
         resp = client.post(
             f"/api/v1/settings/import/{acct.id}",
@@ -464,7 +464,7 @@ def test_bulk_import_skips_llm_when_flag_set(auth_client, session):
     client, user = auth_client
 
     with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model",
+        "http://fake-llm", "fake-key", "test-model", 10,
     )), patch("httpx.post") as mock_post:
         resp = client.post(
             "/api/v1/settings/bulk-import",
@@ -507,7 +507,7 @@ def test_bulk_import_categorizes_via_llm_fallback(auth_client, session):
         return resp
 
     with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model",
+        "http://fake-llm", "fake-key", "test-model", 10,
     )), patch("httpx.post", side_effect=fake_llm_response):
         resp = client.post("/api/v1/settings/bulk-import", json={
             "accounts": [],

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -292,8 +292,8 @@ def test_auto_categorize_with_rules(auth_client, session):
 
 # -- Auto-categorize LLM batching ------------------------------------------
 
-def test_auto_categorize_llm_per_transaction(auth_client, session):
-    """LLM is called once per transaction (not batched)."""
+def test_auto_categorize_llm_batched(auth_client, session):
+    """LLM calls are batched: 5 txns with batch_size=10 should make 1 LLM call."""
     from unittest.mock import patch, MagicMock
     import json as _json
 
@@ -320,7 +320,7 @@ def test_auto_categorize_llm_per_transaction(auth_client, session):
         return resp
 
     with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model",
+        "http://fake-llm", "fake-key", "test-model", 10,
     )), patch("httpx.post", side_effect=fake_llm_response) as mock_post:
         resp = client.post("/api/v1/transactions/auto-categorize")
 
@@ -329,11 +329,49 @@ def test_auto_categorize_llm_per_transaction(auth_client, session):
     assert data["total"] == 5
     assert data["categorized"] == 5
     assert data["skipped"] == 0
-    assert mock_post.call_count == 5  # one per transaction
+    assert mock_post.call_count == 1  # batched into 1 call
+
+
+def test_auto_categorize_llm_respects_batch_size(auth_client, session):
+    """7 txns with batch_size=3 should make 3 LLM calls (3+3+1)."""
+    from unittest.mock import patch, MagicMock
+    import json as _json
+
+    client, user = auth_client
+    acct = make_account(session, user)
+    for i in range(7):
+        make_transaction(
+            session, user, merchant=f"Merchant {i}", category=None,
+            account=acct, is_manual=False,
+        )
+
+    def fake_llm_response(url, **kwargs):
+        body = kwargs.get("json", {})
+        user_msg = body["messages"][1]["content"]
+        input_txns = _json.loads(user_msg)
+        result = [{"id": t["id"], "category": "Shopping"} for t in input_txns]
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "choices": [{"message": {"content": _json.dumps(result)}}]
+        }
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    with patch("app.categorizer._get_llm_config", return_value=(
+        "http://fake-llm", "fake-key", "test-model", 3,
+    )), patch("httpx.post", side_effect=fake_llm_response) as mock_post:
+        resp = client.post("/api/v1/transactions/auto-categorize")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 7
+    assert data["categorized"] == 7
+    assert mock_post.call_count == 3  # ceil(7/3) = 3 calls
 
 
 def test_auto_categorize_llm_partial_failure(auth_client, session):
-    """If some per-txn LLM calls fail, the successful ones are preserved."""
+    """If a batch fails with ConnectError, remaining batches are skipped."""
     from unittest.mock import patch, MagicMock
     import json as _json
 
@@ -364,21 +402,21 @@ def test_auto_categorize_llm_partial_failure(auth_client, session):
         return resp
 
     with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model",
+        "http://fake-llm", "fake-key", "test-model", 1,
     )), patch("httpx.post", side_effect=fake_llm_response):
         resp = client.post("/api/v1/transactions/auto-categorize")
 
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 5
-    assert data["categorized"] == 4  # 4 succeeded, 1 failed
-    assert data["skipped"] == 1
+    assert data["categorized"] == 2  # 2 succeeded before ConnectError
+    assert data["skipped"] == 3  # 3rd failed + 4th/5th skipped (break on ConnectError)
 
 
 # -- Auto-categorize streaming ---------------------------------------------
 
 def test_auto_categorize_streaming(auth_client, session):
-    """Auto-categorize with Accept: application/x-ndjson streams per-txn progress."""
+    """Streaming auto-categorize batches LLM calls but yields per-txn progress."""
     from unittest.mock import patch, MagicMock
     import json as _json
 
@@ -404,13 +442,16 @@ def test_auto_categorize_streaming(auth_client, session):
         return resp
 
     with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model",
-    )), patch("httpx.post", side_effect=fake_llm_response):
+        "http://fake-llm", "fake-key", "test-model", 10,
+    )), patch("app.routes.transactions._get_llm_config", return_value=(
+        "http://fake-llm", "fake-key", "test-model", 10,
+    )), patch("httpx.post", side_effect=fake_llm_response) as mock_post:
         resp = client.post(
             "/api/v1/transactions/auto-categorize",
             headers={"Accept": "application/x-ndjson"},
         )
 
+    assert mock_post.call_count == 1  # all 3 in one batch
     lines = [l for l in resp.text.strip().split("\n") if l]
     assert len(lines) == 4  # 3 progress + 1 complete
     for i in range(3):


### PR DESCRIPTION
## Summary

- Switch auto-categorization from per-transaction LLM calls to batched LLM calls, reducing API calls and avoiding rate limiting (e.g., OpenAI 429 errors)
- Add configurable `batch_size` field (1–50, default 10) to both `AppLLMConfig` (managed) and `HouseholdLLMConfig` (BYOK), exposed as "Transactions per request" in the Admin LLM Config tab and Settings AI Categorization form
- Streaming endpoint batches LLM calls but still yields per-transaction NDJSON progress events for real-time UI updates

## Changes

### Backend
- `app/models.py`: Add `batch_size: int = Field(default=10)` to `AppLLMConfig` and `HouseholdLLMConfig`
- `app/categorizer.py`: `_get_llm_config` returns 4-tuple `(base_url, api_key, model, batch_size)`; remove `_LLM_BATCH_SIZE` constant; `auto_categorize_pending` runs rules first then batches remaining for LLM
- `app/routes/transactions.py`: Refactor `_auto_categorize_stream` to batch LLM calls while yielding per-transaction progress
- `app/routes/settings.py`: Add `batch_size` with validation (`ge=1, le=50`) to `LLMConfigUpdate` and `AdminLLMConfigUpdate`; include in all GET/PUT responses

### Frontend
- `frontend/lib/types.ts`: Add `batch_size` to `LLMConfig` and `AdminLLMConfig`
- `frontend/lib/api.ts`: Add `batch_size` to update payloads
- `frontend/app/admin/page.tsx`: "Transactions per request" number input in LLM Config tab
- `frontend/app/settings/page.tsx`: "Transactions per request" number input in BYOK config form

### Tests
- 509 backend tests passing (86% coverage)
- 466 frontend tests passing (44 files)

## Test plan
- [x] Backend: batch_size in admin LLM config CRUD (GET returns default, PUT persists custom value, validation rejects 0 and 51)
- [x] Backend: batch_size in BYOK LLM config CRUD (same coverage)
- [x] Backend: categorizer resolution returns batch_size from both managed and BYOK configs
- [x] Backend: auto-categorize batches LLM calls (5 txns with batch_size=10 → 1 call; 7 txns with batch_size=3 → 3 calls)
- [x] Backend: streaming auto-categorize batches LLM but yields per-transaction progress
- [x] Backend: partial failure with ConnectError breaks remaining batches
- [x] Frontend: "Transactions per request" field renders in admin LLM Config tab
- [x] Frontend: "Transactions per request" field renders in settings BYOK form with correct value

Made with [Cursor](https://cursor.com)