### PR TITLE
feat: unified import + categorization drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,13 @@ A self-hosted personal finance platform that aggregates bank accounts via Plaid,
 - Configurable per-route and global rate limiting (`memory` or `redis` backend)
 - Readiness endpoint (`/health/ready`) checks database and Redis dependencies
 
-### Global Categorization Progress Drawer
-- **Persistent progress drawer** -- fixed bottom-right card shows real-time progress during Plaid sync and auto-categorization, surviving page navigation
+### Global Progress Drawer
+- **Persistent progress drawer** -- fixed bottom-right card shows real-time progress during CSV imports, Plaid sync, and auto-categorization, surviving page navigation
+- **Import phase** -- displays account name, current merchant, and progress bar; CSV dialogs close immediately and hand off to the drawer
 - **Sync phase** -- displays institution name and account progress (e.g. "Syncing Chase... Account 1 of 3")
 - **Categorization phase** -- shows merchant name, assigned category badge, and progress bar (current/total)
-- **Completion summary** -- displays synced count, categorized count, and skipped count
+- **Automatic chaining** -- after import, auto-categorization starts automatically if uncategorized transactions remain
+- **Completion summary** -- displays imported count, synced count, categorized count, and skipped count
 - **Error handling** -- displays error message with dismiss button
 - **Manual dismiss** -- completion and error states show an X button to reset to idle
 - Triggers from both the Sync Now button (connections page) and Auto-Categorize button (transactions page)
@@ -269,8 +271,8 @@ personal-finance/
 │   │   ├── plaid-setup-banner.tsx  # Dismissible Plaid config prompt (hidden for managed mode)
 │   │   ├── link-account.tsx        # Plaid Link flow (mode-aware: managed skips config redirect)
 │   │   ├── onboarding-redirect.tsx # Dashboard redirect to /onboarding when plaid_mode or llm_mode is null
-│   │   ├── categorization-progress-provider.tsx # Global categorization progress context
-│   │   ├── categorization-drawer.tsx  # Persistent progress drawer (fixed bottom-right)
+│   │   ├── categorization-progress-provider.tsx # Global progress context (sync, categorize, import)
+│   │   ├── categorization-drawer.tsx  # Persistent progress drawer (importing, syncing, categorizing, complete)
 │   │   ├── sync-button.tsx         # Trigger sync for all items (uses global context)
 │   │   ├── net-worth-card.tsx      # Net worth summary
 │   │   ├── net-worth-history.tsx   # Net worth line chart
@@ -282,8 +284,8 @@ personal-finance/
 │   │   ├── goals-snippet.tsx       # Goals progress summary
 │   │   ├── top-movers.tsx          # Top spending category changes
 │   │   ├── cashflow-bar-chart.tsx  # Income vs expenses bar chart with drill-down
-│   │   ├── csv-import-dialog.tsx   # Import Transactions to a single account
-│   │   ├── bulk-csv-import-dialog.tsx # Bulk Import Accounts & Transactions
+│   │   ├── csv-import-dialog.tsx   # CSV import wizard (upload, map columns, preview); hands off to drawer for progress
+│   │   ├── bulk-csv-import-dialog.tsx # Bulk import wizard (upload, columns, accounts, categories, preview); hands off to drawer
 │   │   ├── balance-import-dialog.tsx # Bulk Import Accounts & Balances
 │   │   └── confirm-dialog.tsx      # Reusable confirmation modal
 │   ├── middleware.ts                # Staging password gate (active when STAGING_PASSWORD is set)
@@ -308,8 +310,8 @@ personal-finance/
 │       ├── csv-utils.test.ts       # CSV parser, column role guessing, date normalization, row mapping
 │       ├── rule-utils.test.ts     # Keyword option generation for rule suggestions
 │       ├── accounts-page.test.tsx  # Manual/Plaid account rendering, add form, import/delete actions, edit modal
-│       ├── csv-import-dialog.test.tsx # Upload, column mapping, debit/credit, preview, import flow
-│       ├── bulk-csv-import-dialog.test.tsx # Bulk upload, multi-account mapping, category matching
+│       ├── csv-import-dialog.test.tsx # Upload, column mapping, debit/credit, preview, startImport handoff
+│       ├── bulk-csv-import-dialog.test.tsx # Bulk upload, multi-account mapping, category matching, startBulkImport handoff
 │       ├── balance-import-dialog.test.tsx # Balance history import dialog
 │       ├── cashflow-bar-chart.test.tsx # Bar chart, drill-down, period switching, breadcrumbs
 │       ├── confirm-dialog.test.tsx # Rendering, variants, ARIA attributes, dismiss
@@ -326,7 +328,7 @@ personal-finance/
 │       ├── loans-widget.test.tsx   # Loan list, total remaining
 │       ├── recurring-widget.test.tsx # Recurring detection, max 6, sort by amount
 │       ├── top-movers.test.tsx     # Investment filter, trend icons
-│       ├── categorization-drawer.test.tsx # Idle, syncing, categorizing, complete, dismiss
+│       ├── categorization-drawer.test.tsx # Idle, syncing, importing, categorizing, complete, import→categorize chain, dismiss
 │       ├── sync-button.test.tsx    # Click, syncing state, idle after completion
 │       ├── review-snippet.test.tsx # Transaction list, "all caught up", view all link
 │       ├── budget-snippet.test.tsx # Personal/shared bars, top 3, "Create one" link
@@ -687,7 +689,7 @@ npm run test:watch                # watch mode
 npx vitest run tests/sidebar.test.tsx  # run a single file
 ```
 
-**What's tested (466 tests across 44 files):**
+**What's tested (458 tests across 44 files):**
 
 | File | Tests | Coverage |
 |------|-------|----------|
@@ -700,8 +702,8 @@ npx vitest run tests/sidebar.test.tsx  # run a single file
 | `sidebar` | 12 | Brand, nav links (including Categories), active state, user avatar, logout, hrefs, Categories position, ARIA navigation role |
 | `accounts-page` | 27 | Empty state, Add/Link buttons, manual vs Plaid account actions, add form with subtype selector, import/delete dialogs, click row navigates to filtered transactions, edit modal with pre-filled fields, save calls updateAccount, balance disabled for Plaid, friendly type/subtype labels, statement day in add form and edit modal (appears, submits, pre-fills, editable for Plaid), auto-open add form via ?add=true query param, explicit required-name validation, create mutation error rendering |
 | `confirm-dialog` | 11 | Rendering, variants, callbacks, keyboard/click dismiss, ARIA attributes |
-| `bulk-csv-import-dialog` | 17 | Upload, preview, account detection, category matching, import flow, progress, results, errors, payload validation, auto-categorize trigger after import |
-| `csv-import-dialog` | 16 | Upload, column mapping, debit/credit, preview, import, progress, results, errors, cancel/done, auto-categorize trigger after import |
+| `bulk-csv-import-dialog` | 12 | Upload, preview, account detection, category matching, startBulkImport handoff with onClose, payload validation, fallback account, new categories |
+| `csv-import-dialog` | 10 | Upload, column mapping, debit/credit, preview, startImport handoff with onClose, cancel, back navigation |
 | `goals-page` | 12 | Title, empty state, active/completed sections, progress bar, target date, create dialog, shared summary, delete confirm, create validation message for zero target amount, contribution validation message for zero amount |
 | `statement-reminder-banner` | 5 | Banner rendering, empty state, dismiss with localStorage, dismissed stays hidden, multiple banners |
 | `invitation-banner` | 9 | Visibility, inviter details, accept/decline, dismiss, multiple invites |
@@ -723,7 +725,7 @@ npx vitest run tests/sidebar.test.tsx  # run a single file
 | `budget-snippet` | 8 | Loading, empty with "Create one" link, personal/shared totals, top-3 category sort, expanded shared categories in personal scope, partner scope, and household scope, view all link |
 | `login-page` | 5 | Hero section, trust badges, feature cards, Google sign-in flow |
 | `loans-widget` | 4 | Loading, empty, loan list, total remaining |
-| `categorization-drawer` | 5 | Idle hidden, syncing state, categorizing progress, completion summary with dismiss, dismiss resets to idle |
+| `categorization-drawer` | 9 | Idle hidden, syncing state, importing state with account name, importing→complete transition, import→categorize chain, bulk import progress, categorizing progress, completion summary with dismiss, dismiss resets to idle |
 | `sync-button` | 4 | Idle state, click triggers sync stream, syncing state (disabled), returns to idle after completion |
 | `review-snippet` | 4 | Loading, empty "all caught up", transaction list, view all link |
 | `dashboard-actions` | 6 | Add Account/Link Account/Add Partner buttons, partner status message, navigation to /accounts?add=true, partner dialog open |
@@ -744,8 +746,8 @@ npx vitest run tests/sidebar.test.tsx  # run a single file
 
 ### Latest coverage snapshot
 
-- Backend (`pytest --cov=app --cov-report=term`): **86% total** (`4214` statements, `595` missed)
-- Frontend (`npx vitest run --coverage`): **76.28% statements**, **71.95% branches**, **61.95% functions**, **77.19% lines**
+- Backend (`pytest --cov=app --cov-report=term`): **86% total** (`4215` statements, `595` missed)
+- Frontend (`npx vitest run --coverage`): **76% statements**, **72% branches**, **62% functions**, **77% lines**
 
 ## Environment Variables
 

--- a/frontend/components/bulk-csv-import-dialog.tsx
+++ b/frontend/components/bulk-csv-import-dialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useRef, useMemo } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Upload, X, Loader2, CheckCircle2, AlertCircle, ArrowLeft, ArrowRight } from "lucide-react";
-import { api, BulkImportPayload, ImportProgressEvent, ImportCompleteEvent } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { Upload, X, AlertCircle, ArrowLeft, ArrowRight } from "lucide-react";
+import { api, BulkImportPayload } from "@/lib/api";
 import { useCategorizationProgress } from "@/components/categorization-progress-provider";
 import { useHousehold } from "@/components/household-provider";
 import { ACCOUNT_TYPES, SUBTYPES } from "@/app/accounts/page";
@@ -22,11 +22,10 @@ interface Props {
   onClose: () => void;
 }
 
-type Step = "upload" | "columns" | "accounts" | "categories" | "preview" | "importing" | "result";
+type Step = "upload" | "columns" | "accounts" | "categories" | "preview";
 
 export default function BulkCsvImportDialog({ onClose }: Props) {
-  const queryClient = useQueryClient();
-  const { startAutoCategorize } = useCategorizationProgress();
+  const { startBulkImport } = useCategorizationProgress();
   const { data: llmConfig } = useQuery({ queryKey: ["llm-config"], queryFn: api.getLLMConfig });
   const fileRef = useRef<HTMLInputElement>(null);
   const { household } = useHousehold();
@@ -35,8 +34,6 @@ export default function BulkCsvImportDialog({ onClose }: Props) {
   const [sourceFileName, setSourceFileName] = useState("");
   const [columnRoles, setColumnRoles] = useState<ColumnRole[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [progress, setProgress] = useState<ImportProgressEvent | null>(null);
-  const [result, setResult] = useState<ImportCompleteEvent | null>(null);
   const [negateAmounts, setNegateAmounts] = useState(false);
   const [accountMeta, setAccountMeta] = useState<Record<string, { type: string; subtype: string; balance: string }>>({});
 
@@ -152,67 +149,50 @@ export default function BulkCsvImportDialog({ onClose }: Props) {
     }
   }
 
-  async function handleImport() {
-    setStep("importing");
-    setError(null);
-    try {
-      const newAccountNames = csvAccountNames.filter(
-        (n) => !existingAccountNames.has(n.toLowerCase()),
-      );
-      const fallbackAccountNameBase = sourceFileName.replace(/\.[^/.]+$/, "").trim();
-      const fallbackAccountName = fallbackAccountNameBase || "Imported Account";
-      const shouldCreateFallbackAccount =
-        newAccountNames.length === 0 &&
-        csvAccountNames.length === 0 &&
-        (existingAccounts?.length ?? 0) === 0;
-      const newCategories = categoryMatches
-        .filter((m) => m.isNew)
-        .map((m) => m.csvCategory);
-      const transactionsForImport = shouldCreateFallbackAccount
-        ? mappedRows.map((row) => ({ ...row, account_name: fallbackAccountName }))
-        : mappedRows;
+  function handleImport() {
+    const newAccountNames = csvAccountNames.filter(
+      (n) => !existingAccountNames.has(n.toLowerCase()),
+    );
+    const fallbackAccountNameBase = sourceFileName.replace(/\.[^/.]+$/, "").trim();
+    const fallbackAccountName = fallbackAccountNameBase || "Imported Account";
+    const shouldCreateFallbackAccount =
+      newAccountNames.length === 0 &&
+      csvAccountNames.length === 0 &&
+      (existingAccounts?.length ?? 0) === 0;
+    const newCategories = categoryMatches
+      .filter((m) => m.isNew)
+      .map((m) => m.csvCategory);
+    const transactionsForImport = shouldCreateFallbackAccount
+      ? mappedRows.map((row) => ({ ...row, account_name: fallbackAccountName }))
+      : mappedRows;
 
-      const payload: BulkImportPayload = {
-        accounts: [
-          ...newAccountNames.map((name) => {
-            const m = accountMeta[name];
-            return {
-              name,
-              type: m?.type ?? "depository",
-              subtype: m?.subtype ?? SUBTYPES["depository"]?.[0] ?? "",
-              current_balance: parseFloat(m?.balance ?? "0") || 0,
-            };
-          }),
-          ...(shouldCreateFallbackAccount
-            ? [{
-                name: fallbackAccountName,
-                type: "depository",
-                subtype: SUBTYPES["depository"]?.[0] ?? "",
-                current_balance: 0,
-              }]
-            : []),
-        ],
-        transactions: transactionsForImport,
-        new_categories: newCategories,
-        skip_llm: true,
-      };
+    const payload: BulkImportPayload = {
+      accounts: [
+        ...newAccountNames.map((name) => {
+          const m = accountMeta[name];
+          return {
+            name,
+            type: m?.type ?? "depository",
+            subtype: m?.subtype ?? SUBTYPES["depository"]?.[0] ?? "",
+            current_balance: parseFloat(m?.balance ?? "0") || 0,
+          };
+        }),
+        ...(shouldCreateFallbackAccount
+          ? [{
+              name: fallbackAccountName,
+              type: "depository",
+              subtype: SUBTYPES["depository"]?.[0] ?? "",
+              current_balance: 0,
+            }]
+          : []),
+      ],
+      transactions: transactionsForImport,
+      new_categories: newCategories,
+      skip_llm: true,
+    };
 
-      const complete = await api.bulkImportTransactions(payload, (evt) =>
-        setProgress(evt),
-      );
-      setResult(complete);
-      setStep("result");
-      queryClient.invalidateQueries({ queryKey: ["transactions"] });
-      queryClient.invalidateQueries({ queryKey: ["accounts"] });
-      queryClient.invalidateQueries({ queryKey: ["accountSummary"] });
-      queryClient.invalidateQueries({ queryKey: ["categories"] });
-      if (complete.imported > complete.categorized) {
-        startAutoCategorize();
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Import failed");
-      setStep("preview");
-    }
+    startBulkImport(payload);
+    onClose();
   }
 
   const selectClass =
@@ -220,9 +200,7 @@ export default function BulkCsvImportDialog({ onClose }: Props) {
 
   const stepLabels = ["Upload", "Map Columns", "Accounts", "Categories", "Preview"];
   const stepOrder: Step[] = ["upload", "columns", "accounts", "categories", "preview"];
-  const currentStepIdx = stepOrder.indexOf(
-    step === "importing" || step === "result" ? "preview" : step,
-  );
+  const currentStepIdx = stepOrder.indexOf(step);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
@@ -567,56 +545,6 @@ export default function BulkCsvImportDialog({ onClose }: Props) {
           </div>
         )}
 
-        {/* ── Importing ── */}
-        {step === "importing" && (
-          <div className="space-y-4 py-4">
-            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Importing...
-            </div>
-            {progress && (
-              <div className="space-y-1">
-                <div className="flex justify-between text-xs text-muted-foreground">
-                  <span className="truncate max-w-[200px]">{progress.merchant}</span>
-                  <span>{progress.current}/{progress.total}</span>
-                </div>
-                <div className="h-1.5 rounded-full bg-muted overflow-hidden">
-                  <div
-                    className="h-full rounded-full bg-accent transition-all"
-                    style={{ width: `${(progress.current / progress.total) * 100}%` }}
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* ── Result ── */}
-        {step === "result" && result && (
-          <div className="space-y-3">
-            <div className="flex items-center gap-2 text-green-400">
-              <CheckCircle2 className="h-5 w-5" />
-              <span className="font-medium">Import complete</span>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {result.imported} imported, {result.skipped} skipped, {result.categorized} auto-categorized
-            </p>
-            {result.errors.length > 0 && (
-              <div className="rounded-lg bg-red-500/10 p-3 text-xs text-red-400">
-                {result.errors.slice(0, 5).map((e, i) => (
-                  <p key={i}>{e}</p>
-                ))}
-                {result.errors.length > 5 && <p>...and {result.errors.length - 5} more</p>}
-              </div>
-            )}
-            <button
-              onClick={onClose}
-              className="w-full rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground"
-            >
-              Done
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/frontend/components/categorization-drawer.tsx
+++ b/frontend/components/categorization-drawer.tsx
@@ -15,7 +15,12 @@ export default function CategorizationDrawer() {
     catTotal,
     merchantName,
     category,
+    importCurrent,
+    importTotal,
+    importMerchant,
+    importAccountName,
     result,
+    importResult,
     errorMessage,
     dismiss,
   } = useCategorizationProgress();
@@ -37,6 +42,35 @@ export default function CategorizationDrawer() {
                 <p className="text-xs text-muted-foreground">
                   Account {syncCurrent} of {syncTotal}
                 </p>
+              )}
+            </div>
+          )}
+
+          {state === "importing" && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                Importing to {importAccountName}...
+              </div>
+              {importMerchant && (
+                <p className="truncate text-xs text-muted-foreground">
+                  {importMerchant}
+                </p>
+              )}
+              {importTotal > 0 && (
+                <>
+                  <div className="flex justify-between text-xs text-muted-foreground">
+                    <span>{importCurrent} / {importTotal}</span>
+                  </div>
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-accent transition-all duration-200"
+                      style={{
+                        width: `${(importCurrent / importTotal) * 100}%`,
+                      }}
+                    />
+                  </div>
+                </>
               )}
             </div>
           )}
@@ -79,9 +113,12 @@ export default function CategorizationDrawer() {
             <div className="space-y-1">
               <div className="flex items-center gap-2 text-sm font-medium text-success">
                 <CheckCircle className="h-4 w-4 shrink-0" />
-                Sync complete
+                {importResult ? "Import complete" : "Sync complete"}
               </div>
               <p className="text-xs text-muted-foreground">
+                {importResult && (
+                  <>Imported {importResult.imported} transactions{importResult.skipped > 0 && `, ${importResult.skipped} skipped`}. </>
+                )}
                 {result.synced > 0 && (
                   <>Synced {result.synced} transactions. </>
                 )}

--- a/frontend/components/categorization-progress-provider.tsx
+++ b/frontend/components/categorization-progress-provider.tsx
@@ -15,9 +15,19 @@ import {
   type SyncProgressEvent,
   type SyncCompleteEvent,
   type AutoCatCompleteEvent,
+  type ImportProgressEvent,
+  type ImportCompleteEvent,
+  type BulkImportPayload,
 } from "@/lib/api";
 
-type ProgressState = "idle" | "syncing" | "categorizing" | "complete" | "error";
+type ImportRow = { date: string; amount: number; merchant_name: string; category?: string };
+
+type ProgressState = "idle" | "importing" | "syncing" | "categorizing" | "complete" | "error";
+
+interface ImportResult {
+  imported: number;
+  skipped: number;
+}
 
 interface CategorizationProgressValue {
   state: ProgressState;
@@ -28,10 +38,17 @@ interface CategorizationProgressValue {
   catTotal: number;
   merchantName: string | null;
   category: string | null;
+  importCurrent: number;
+  importTotal: number;
+  importMerchant: string | null;
+  importAccountName: string | null;
   result: { synced: number; categorized: number; skipped: number } | null;
+  importResult: ImportResult | null;
   errorMessage: string | null;
   startSync: () => void;
   startAutoCategorize: () => void;
+  startImport: (accountId: number, accountName: string, rows: ImportRow[]) => void;
+  startBulkImport: (payload: BulkImportPayload) => void;
   dismiss: () => void;
 }
 
@@ -44,10 +61,17 @@ const INITIAL: CategorizationProgressValue = {
   catTotal: 0,
   merchantName: null,
   category: null,
+  importCurrent: 0,
+  importTotal: 0,
+  importMerchant: null,
+  importAccountName: null,
   result: null,
+  importResult: null,
   errorMessage: null,
   startSync: () => {},
   startAutoCategorize: () => {},
+  startImport: () => {},
+  startBulkImport: () => {},
   dismiss: () => {},
 };
 
@@ -89,6 +113,11 @@ export function CategorizationProgressProvider({
     skipped: number;
   } | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [importCurrent, setImportCurrent] = useState(0);
+  const [importTotal, setImportTotal] = useState(0);
+  const [importMerchant, setImportMerchant] = useState<string | null>(null);
+  const [importAccountName, setImportAccountName] = useState<string | null>(null);
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
 
   const runningRef = useRef(false);
   const queryClient = useQueryClient();
@@ -108,7 +137,12 @@ export function CategorizationProgressProvider({
     setCatTotal(0);
     setMerchantName(null);
     setCategory(null);
+    setImportCurrent(0);
+    setImportTotal(0);
+    setImportMerchant(null);
+    setImportAccountName(null);
     setResult(null);
+    setImportResult(null);
     setErrorMessage(null);
     runningRef.current = false;
   }, []);
@@ -181,6 +215,111 @@ export function CategorizationProgressProvider({
       });
   }, [invalidateAll]);
 
+  const chainAutoCategorize = useCallback(
+    (impResult: ImportResult) => {
+      setState("categorizing");
+      api
+        .autoCategorize((event: AutoCatProgressEvent) => {
+          setCatCurrent(event.current);
+          setCatTotal(event.total);
+          setMerchantName(event.merchant_name);
+          setCategory(event.category);
+        })
+        .then((complete: AutoCatCompleteEvent) => {
+          setResult({
+            synced: 0,
+            categorized: complete.categorized,
+            skipped: complete.skipped,
+          });
+          setImportResult(impResult);
+          setState("complete");
+          runningRef.current = false;
+          invalidateAll();
+        })
+        .catch((err: Error) => {
+          setErrorMessage(err.message);
+          setState("error");
+          runningRef.current = false;
+        });
+    },
+    [invalidateAll],
+  );
+
+  const startImport = useCallback(
+    (accountId: number, accountName: string, rows: ImportRow[]) => {
+      if (runningRef.current) return;
+      runningRef.current = true;
+      setState("importing");
+      setImportAccountName(accountName);
+
+      api
+        .streamImportTransactions(
+          accountId,
+          rows,
+          (evt: ImportProgressEvent) => {
+            setImportCurrent(evt.current);
+            setImportTotal(evt.total);
+            setImportMerchant(evt.merchant);
+          },
+          true,
+        )
+        .then((complete: ImportCompleteEvent) => {
+          const impResult = { imported: complete.imported, skipped: complete.skipped };
+          invalidateAll();
+          if (complete.imported > complete.categorized) {
+            setImportResult(impResult);
+            chainAutoCategorize(impResult);
+          } else {
+            setResult({ synced: 0, categorized: complete.categorized, skipped: 0 });
+            setImportResult(impResult);
+            setState("complete");
+            runningRef.current = false;
+          }
+        })
+        .catch((err: Error) => {
+          setErrorMessage(err.message);
+          setState("error");
+          runningRef.current = false;
+        });
+    },
+    [invalidateAll, chainAutoCategorize],
+  );
+
+  const startBulkImport = useCallback(
+    (payload: BulkImportPayload) => {
+      if (runningRef.current) return;
+      runningRef.current = true;
+      setState("importing");
+      setImportAccountName("Bulk Import");
+
+      api
+        .bulkImportTransactions(payload, (evt: ImportProgressEvent) => {
+          setImportCurrent(evt.current);
+          setImportTotal(evt.total);
+          setImportMerchant(evt.merchant);
+        })
+        .then((complete: ImportCompleteEvent) => {
+          const impResult = { imported: complete.imported, skipped: complete.skipped };
+          invalidateAll();
+          if (complete.imported > complete.categorized) {
+            setImportResult(impResult);
+            chainAutoCategorize(impResult);
+          } else {
+            setResult({ synced: 0, categorized: complete.categorized, skipped: 0 });
+            setImportResult(impResult);
+            setState("complete");
+            runningRef.current = false;
+          }
+        })
+        .catch((err: Error) => {
+          setErrorMessage(err.message);
+          setState("error");
+          runningRef.current = false;
+        });
+    },
+    [invalidateAll, chainAutoCategorize],
+  );
+
   const dismiss = useCallback(() => {
     reset();
   }, [reset]);
@@ -196,10 +335,17 @@ export function CategorizationProgressProvider({
         catTotal,
         merchantName,
         category,
+        importCurrent,
+        importTotal,
+        importMerchant,
+        importAccountName,
         result,
+        importResult,
         errorMessage,
         startSync,
         startAutoCategorize,
+        startImport,
+        startBulkImport,
         dismiss,
       }}
     >

--- a/frontend/components/csv-import-dialog.tsx
+++ b/frontend/components/csv-import-dialog.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useState, useRef, useMemo } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Upload, X, Loader2, CheckCircle2, AlertCircle, ArrowLeft, ArrowRight } from "lucide-react";
-import { api, ImportProgressEvent, ImportCompleteEvent } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { Upload, X, AlertCircle, ArrowLeft, ArrowRight } from "lucide-react";
+import { api } from "@/lib/api";
 import { useCategorizationProgress } from "@/components/categorization-progress-provider";
-import type { LLMConfig } from "@/lib/types";
 import {
   parseCsv,
   guessRole,
@@ -21,19 +20,16 @@ interface Props {
   onClose: () => void;
 }
 
-type Step = "upload" | "columns" | "preview" | "importing" | "result";
+type Step = "upload" | "columns" | "preview";
 
 export default function CsvImportDialog({ accountId, accountName, onClose }: Props) {
-  const queryClient = useQueryClient();
-  const { startAutoCategorize } = useCategorizationProgress();
+  const { startImport } = useCategorizationProgress();
   const { data: llmConfig } = useQuery({ queryKey: ["llm-config"], queryFn: api.getLLMConfig });
   const fileRef = useRef<HTMLInputElement>(null);
   const [step, setStep] = useState<Step>("upload");
   const [rawRows, setRawRows] = useState<string[][]>([]);
   const [columnRoles, setColumnRoles] = useState<ColumnRole[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [progress, setProgress] = useState<ImportProgressEvent | null>(null);
-  const [result, setResult] = useState<ImportCompleteEvent | null>(null);
   const [negateAmounts, setNegateAmounts] = useState(false);
 
   const headers = rawRows[0] ?? [];
@@ -75,28 +71,9 @@ export default function CsvImportDialog({ accountId, accountName, onClose }: Pro
     });
   }
 
-  async function handleImport() {
-    setStep("importing");
-    setError(null);
-    try {
-      const complete = await api.streamImportTransactions(
-        accountId,
-        mappedRows,
-        (evt) => setProgress(evt),
-        true,
-      );
-      setResult(complete);
-      setStep("result");
-      queryClient.invalidateQueries({ queryKey: ["transactions"] });
-      queryClient.invalidateQueries({ queryKey: ["accounts"] });
-      queryClient.invalidateQueries({ queryKey: ["accountSummary"] });
-      if (complete.imported > complete.categorized) {
-        startAutoCategorize();
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Import failed");
-      setStep("preview");
-    }
+  function handleImport() {
+    startImport(accountId, accountName, mappedRows);
+    onClose();
   }
 
   const selectClass =
@@ -119,9 +96,7 @@ export default function CsvImportDialog({ accountId, accountName, onClose }: Pro
         <div className="mb-4 flex gap-1">
           {(["Upload", "Map Columns", "Preview"] as const).map((label, i) => {
             const stepOrder: Step[] = ["upload", "columns", "preview"];
-            const active = stepOrder.indexOf(
-              step === "importing" || step === "result" ? "preview" : step,
-            ) >= i;
+            const active = stepOrder.indexOf(step) >= i;
             return (
               <div
                 key={label}
@@ -323,56 +298,6 @@ export default function CsvImportDialog({ accountId, accountName, onClose }: Pro
           </div>
         )}
 
-        {/* ── Importing step ── */}
-        {step === "importing" && (
-          <div className="space-y-4 py-4">
-            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Importing...
-            </div>
-            {progress && (
-              <div className="space-y-1">
-                <div className="flex justify-between text-xs text-muted-foreground">
-                  <span className="truncate max-w-[200px]">{progress.merchant}</span>
-                  <span>{progress.current}/{progress.total}</span>
-                </div>
-                <div className="h-1.5 rounded-full bg-muted overflow-hidden">
-                  <div
-                    className="h-full rounded-full bg-accent transition-all"
-                    style={{ width: `${(progress.current / progress.total) * 100}%` }}
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* ── Result step ── */}
-        {step === "result" && result && (
-          <div className="space-y-3">
-            <div className="flex items-center gap-2 text-green-400">
-              <CheckCircle2 className="h-5 w-5" />
-              <span className="font-medium">Import complete</span>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {result.imported} imported, {result.skipped} skipped, {result.categorized} auto-categorized
-            </p>
-            {result.errors.length > 0 && (
-              <div className="rounded-lg bg-red-500/10 p-3 text-xs text-red-400">
-                {result.errors.slice(0, 5).map((e, i) => (
-                  <p key={i}>{e}</p>
-                ))}
-                {result.errors.length > 5 && <p>...and {result.errors.length - 5} more</p>}
-              </div>
-            )}
-            <button
-              onClick={onClose}
-              className="w-full rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground"
-            >
-              Done
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/frontend/tests/bulk-csv-import-dialog.test.tsx
+++ b/frontend/tests/bulk-csv-import-dialog.test.tsx
@@ -5,11 +5,10 @@ import BulkCsvImportDialog from "@/components/bulk-csv-import-dialog";
 import { renderWithProviders, TEST_CATEGORIES } from "./helpers";
 
 const mockApi = vi.hoisted(() => ({
-  bulkImportTransactions: vi.fn(),
   getAccounts: vi.fn(),
   getCategories: vi.fn(),
 }));
-const mockStartAutoCategorize = vi.hoisted(() => vi.fn());
+const mockStartBulkImport = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api", () => ({ api: mockApi }));
 
@@ -19,7 +18,7 @@ vi.mock("@/components/household-provider", () => ({
 
 vi.mock("@/components/categorization-progress-provider", () => ({
   useCategorizationProgress: () => ({
-    startAutoCategorize: mockStartAutoCategorize,
+    startBulkImport: mockStartBulkImport,
   }),
 }));
 
@@ -55,13 +54,6 @@ describe("BulkCsvImportDialog", () => {
     vi.clearAllMocks();
     mockApi.getAccounts.mockResolvedValue([]);
     mockApi.getCategories.mockResolvedValue([]);
-    mockApi.bulkImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 2,
-      skipped: 0,
-      categorized: 0,
-      errors: [],
-    });
   });
 
   it("renders upload step with file upload button", () => {
@@ -166,15 +158,9 @@ describe("BulkCsvImportDialog", () => {
     await waitFor(() => {
       expect(screen.getByText(/Ready to import/)).toBeInTheDocument();
     });
-
-    await user.click(screen.getByText(/Import 1 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-    });
   });
 
-  it("Import calls bulkImportTransactions with correct payload", async () => {
+  it("Import calls startBulkImport with correct payload and closes dialog", async () => {
     mockApi.getCategories.mockResolvedValue(TEST_CATEGORIES);
     const user = userEvent.setup();
     renderWithProviders(<BulkCsvImportDialog onClose={onClose} />);
@@ -189,8 +175,8 @@ describe("BulkCsvImportDialog", () => {
     await user.click(screen.getByText(/Import 1 transactions/));
 
     await waitFor(() => {
-      expect(mockApi.bulkImportTransactions).toHaveBeenCalled();
-      const [payload] = mockApi.bulkImportTransactions.mock.calls[0];
+      expect(mockStartBulkImport).toHaveBeenCalled();
+      const [payload] = mockStartBulkImport.mock.calls[0];
       expect(payload.accounts).toEqual([{ name: "Visa", type: "depository", subtype: "Cash Management", current_balance: 0 }]);
       expect(payload.transactions).toHaveLength(1);
       expect(payload.transactions[0]).toMatchObject({
@@ -201,6 +187,7 @@ describe("BulkCsvImportDialog", () => {
         account_name: "Visa",
       });
       expect(payload.skip_llm).toBe(true);
+      expect(onClose).toHaveBeenCalled();
     });
   });
 
@@ -217,8 +204,8 @@ describe("BulkCsvImportDialog", () => {
     await user.click(screen.getByText(/Import 2 transactions/));
 
     await waitFor(() => {
-      expect(mockApi.bulkImportTransactions).toHaveBeenCalled();
-      const [payload] = mockApi.bulkImportTransactions.mock.calls[0];
+      expect(mockStartBulkImport).toHaveBeenCalled();
+      const [payload] = mockStartBulkImport.mock.calls[0];
       expect(payload.accounts).toHaveLength(1);
       expect(payload.accounts[0]).toMatchObject({
         name: "test",
@@ -244,95 +231,6 @@ describe("BulkCsvImportDialog", () => {
     });
   });
 
-  it("shows progress during import", async () => {
-    let resolveImport: (value: unknown) => void;
-    const importPromise = new Promise<unknown>((resolve) => {
-      resolveImport = resolve;
-    });
-    mockApi.bulkImportTransactions.mockImplementation(
-      (_payload: unknown, onProgress: (evt: unknown) => void) => {
-        queueMicrotask(() => {
-          onProgress({ current: 1, total: 1, merchant: "Coffee", status: "", category: null });
-        });
-        return importPromise.then(() => ({
-          type: "complete",
-          imported: 1,
-          skipped: 0,
-          categorized: 0,
-          errors: [],
-        }));
-      },
-    );
-    const user = userEvent.setup();
-    renderWithProviders(<BulkCsvImportDialog onClose={onClose} />);
-    await advanceToPreview(user, "Date,Merchant,Amount\n2026-01-15,Coffee,4.50\n");
-    await waitFor(() => expect(screen.getByText(/Import 1 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 1 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Importing...")).toBeInTheDocument();
-      expect(screen.getByText("1/1")).toBeInTheDocument();
-    });
-
-    resolveImport!(undefined);
-  });
-
-  it("shows results after import", async () => {
-    mockApi.bulkImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 2,
-      skipped: 1,
-      categorized: 1,
-      errors: [],
-    });
-    const user = userEvent.setup();
-    renderWithProviders(<BulkCsvImportDialog onClose={onClose} />);
-
-    await advanceToPreview(
-      user,
-      "Date,Merchant,Amount\n2026-01-15,Coffee,4.50\n2026-01-16,Grocery,42.00\n",
-    );
-
-    await waitFor(() => expect(screen.getByText(/Import 2 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 2 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-      expect(screen.getByText(/2 imported, 1 skipped, 1 auto-categorized/)).toBeInTheDocument();
-    });
-  });
-
-  it("shows errors in results after import", async () => {
-    mockApi.bulkImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 0,
-      skipped: 0,
-      categorized: 0,
-      errors: ["Row 1: unknown account 'Missing'"],
-    });
-    const user = userEvent.setup();
-    renderWithProviders(<BulkCsvImportDialog onClose={onClose} />);
-    await advanceToPreview(user, "Date,Merchant,Amount\n2026-01-15,Coffee,4.50\n");
-    await waitFor(() => expect(screen.getByText(/Import 1 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 1 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-      expect(screen.getByText("Row 1: unknown account 'Missing'")).toBeInTheDocument();
-    });
-  });
-
-  it("Done button calls onClose", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<BulkCsvImportDialog onClose={onClose} />);
-    await advanceToPreview(user, "Date,Merchant,Amount\n2026-01-15,Coffee,4.50\n");
-    await waitFor(() => expect(screen.getByText(/Import 1 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 1 transactions/));
-
-    await waitFor(() => expect(screen.getByText("Done")).toBeInTheDocument());
-    await user.click(screen.getByText("Done"));
-    expect(onClose).toHaveBeenCalled();
-  });
 
   it("Back button in columns returns to upload", async () => {
     const user = userEvent.setup();
@@ -347,55 +245,6 @@ describe("BulkCsvImportDialog", () => {
     });
   });
 
-  it("triggers auto-categorize after import when uncategorized transactions exist", async () => {
-    mockApi.bulkImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 3,
-      skipped: 0,
-      categorized: 1,
-      errors: [],
-    });
-    const user = userEvent.setup();
-    renderWithProviders(<BulkCsvImportDialog onClose={onClose} />);
-
-    await advanceToPreview(
-      user,
-      "Date,Merchant,Amount\n2026-01-15,Coffee,4.50\n2026-01-16,Grocery,42.00\n2026-01-17,Gas,35.00\n",
-    );
-
-    await waitFor(() => expect(screen.getByText(/Import 3 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 3 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-      expect(mockStartAutoCategorize).toHaveBeenCalled();
-    });
-  });
-
-  it("does not trigger auto-categorize when all transactions already categorized", async () => {
-    mockApi.bulkImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 2,
-      skipped: 0,
-      categorized: 2,
-      errors: [],
-    });
-    const user = userEvent.setup();
-    renderWithProviders(<BulkCsvImportDialog onClose={onClose} />);
-
-    await advanceToPreview(
-      user,
-      "Date,Merchant,Amount\n2026-01-15,Coffee,4.50\n2026-01-16,Grocery,42.00\n",
-    );
-
-    await waitFor(() => expect(screen.getByText(/Import 2 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 2 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-    });
-    expect(mockStartAutoCategorize).not.toHaveBeenCalled();
-  });
 
   it("includes new_categories in payload for unmatched categories", async () => {
     mockApi.getCategories.mockResolvedValue(TEST_CATEGORIES);
@@ -412,7 +261,7 @@ describe("BulkCsvImportDialog", () => {
     await user.click(screen.getByText(/Import 1 transactions/));
 
     await waitFor(() => {
-      const [payload] = mockApi.bulkImportTransactions.mock.calls[0];
+      const [payload] = mockStartBulkImport.mock.calls[0];
       expect(payload.new_categories).toContain("Crypto Fees");
     });
   });

--- a/frontend/tests/categorization-drawer.test.tsx
+++ b/frontend/tests/categorization-drawer.test.tsx
@@ -9,6 +9,8 @@ import CategorizationDrawer from "@/components/categorization-drawer";
 const mockApi = vi.hoisted(() => ({
   syncAllStream: vi.fn(),
   autoCategorize: vi.fn(),
+  streamImportTransactions: vi.fn(),
+  bulkImportTransactions: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({ api: mockApi }));
@@ -39,6 +41,42 @@ function AutoCatTrigger() {
   return (
     <button onClick={startAutoCategorize} disabled={state !== "idle"}>
       Auto-Categorize
+    </button>
+  );
+}
+
+function ImportTrigger() {
+  const { startImport, state } = useCategorizationProgress();
+  return (
+    <button
+      onClick={() =>
+        startImport(1, "My Checking", [
+          { date: "2026-01-15", amount: 4.5, merchant_name: "Coffee" },
+        ])
+      }
+      disabled={state !== "idle"}
+    >
+      Import
+    </button>
+  );
+}
+
+function BulkImportTrigger() {
+  const { startBulkImport, state } = useCategorizationProgress();
+  return (
+    <button
+      onClick={() =>
+        startBulkImport({
+          accounts: [{ name: "Visa", type: "depository" }],
+          transactions: [
+            { date: "2026-01-15", amount: 4.5, merchant_name: "Coffee", account_name: "Visa" },
+          ],
+          skip_llm: true,
+        })
+      }
+      disabled={state !== "idle"}
+    >
+      Bulk Import
     </button>
   );
 }
@@ -126,6 +164,102 @@ describe("CategorizationDrawer", () => {
     });
 
     expect(screen.getByRole("button", { name: /dismiss|close/i })).toBeInTheDocument();
+  });
+
+  it("shows importing state during import", async () => {
+    let resolveImport: (value: unknown) => void;
+    mockApi.streamImportTransactions.mockImplementation(
+      (_id: number, _rows: unknown[], onProgress: (e: unknown) => void) => {
+        onProgress({ type: "progress", current: 1, total: 3, merchant: "Coffee", status: "imported", category: null });
+        return new Promise((resolve) => { resolveImport = resolve; });
+      },
+    );
+
+    render(
+      <Wrapper>
+        <ImportTrigger />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByText("Import"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Importing/)).toBeInTheDocument();
+      expect(screen.getByText(/My Checking/)).toBeInTheDocument();
+      expect(screen.getByText("1 / 3")).toBeInTheDocument();
+    });
+
+    resolveImport!({ type: "complete", imported: 3, skipped: 0, categorized: 3, errors: [] });
+  });
+
+  it("shows importing then transitions to complete when all categorized", async () => {
+    mockApi.streamImportTransactions.mockResolvedValue({
+      type: "complete", imported: 3, skipped: 0, categorized: 3, errors: [],
+    });
+
+    render(
+      <Wrapper>
+        <ImportTrigger />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByText("Import"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Import complete/)).toBeInTheDocument();
+      expect(screen.getByText(/3/)).toBeInTheDocument();
+    });
+  });
+
+  it("chains import into auto-categorize when uncategorized transactions remain", async () => {
+    mockApi.streamImportTransactions.mockResolvedValue({
+      type: "complete", imported: 5, skipped: 0, categorized: 1, errors: [],
+    });
+    let resolveAutoCat: (value: unknown) => void;
+    mockApi.autoCategorize.mockImplementation((onProgress: (e: unknown) => void) => {
+      onProgress({ status: "categorized", current: 1, total: 4, merchant_name: "Target", category: "Shopping" });
+      return new Promise((resolve) => { resolveAutoCat = resolve; });
+    });
+
+    render(
+      <Wrapper>
+        <ImportTrigger />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByText("Import"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Categorizing/)).toBeInTheDocument();
+      expect(screen.getByText(/Target/)).toBeInTheDocument();
+    });
+
+    resolveAutoCat!({ status: "complete", total: 4, categorized: 3, skipped: 1 });
+  });
+
+  it("shows bulk import progress in drawer", async () => {
+    let resolveBulk: (value: unknown) => void;
+    mockApi.bulkImportTransactions.mockImplementation(
+      (_payload: unknown, onProgress: (e: unknown) => void) => {
+        onProgress({ type: "progress", current: 1, total: 2, merchant: "Grocery", status: "imported", category: null });
+        return new Promise((resolve) => { resolveBulk = resolve; });
+      },
+    );
+
+    render(
+      <Wrapper>
+        <BulkImportTrigger />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByText("Bulk Import"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Importing/)).toBeInTheDocument();
+      expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    });
+
+    resolveBulk!({ type: "complete", imported: 2, skipped: 0, categorized: 2, errors: [] });
   });
 
   it("dismiss resets to idle and hides the drawer", async () => {

--- a/frontend/tests/csv-import-dialog.test.tsx
+++ b/frontend/tests/csv-import-dialog.test.tsx
@@ -5,15 +5,14 @@ import CsvImportDialog from "@/components/csv-import-dialog";
 import { renderWithProviders, TEST_SETTINGS } from "./helpers";
 
 const mockApi = vi.hoisted(() => ({
-  streamImportTransactions: vi.fn(),
   getSettings: vi.fn(),
 }));
-const mockStartAutoCategorize = vi.hoisted(() => vi.fn());
+const mockStartImport = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api", () => ({ api: mockApi }));
 vi.mock("@/components/categorization-progress-provider", () => ({
   useCategorizationProgress: () => ({
-    startAutoCategorize: mockStartAutoCategorize,
+    startImport: mockStartImport,
   }),
 }));
 
@@ -40,13 +39,6 @@ describe("CsvImportDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockApi.getSettings.mockResolvedValue(TEST_SETTINGS);
-    mockApi.streamImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 2,
-      skipped: 0,
-      categorized: 0,
-      errors: [],
-    });
   });
 
   it("renders upload step with file upload button", () => {
@@ -98,7 +90,7 @@ describe("CsvImportDialog", () => {
     });
   });
 
-  it("navigates through all steps: upload → columns → preview → import → result", async () => {
+  it("navigates through all steps: upload → columns → preview", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <CsvImportDialog accountId={42} accountName="Test" onClose={onClose} />,
@@ -113,15 +105,9 @@ describe("CsvImportDialog", () => {
       expect(screen.getByText(/1 transactions ready to import/)).toBeInTheDocument();
       expect(screen.getByText("Coffee Shop")).toBeInTheDocument();
     });
-
-    await user.click(screen.getByText(/Import 1 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-    });
   });
 
-  it("Import calls streamImportTransactions with mapped data", async () => {
+  it("Import calls startImport with mapped data and closes dialog", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <CsvImportDialog accountId={42} accountName="Test" onClose={onClose} />,
@@ -136,8 +122,9 @@ describe("CsvImportDialog", () => {
     await user.click(screen.getByText(/Import 1 transactions/));
 
     await waitFor(() => {
-      expect(mockApi.streamImportTransactions).toHaveBeenCalledWith(
+      expect(mockStartImport).toHaveBeenCalledWith(
         42,
+        "Test",
         [
           {
             date: "2026-01-15",
@@ -146,110 +133,9 @@ describe("CsvImportDialog", () => {
             category: "Food",
           },
         ],
-        expect.any(Function),
-        true,
       );
+      expect(onClose).toHaveBeenCalled();
     });
-  });
-
-  it("shows progress during import", async () => {
-    let resolveImport: (value: unknown) => void;
-    const importPromise = new Promise<unknown>((resolve) => {
-      resolveImport = resolve;
-    });
-    mockApi.streamImportTransactions.mockImplementation(
-      (_id: number, _rows: unknown[], onProgress: (evt: unknown) => void) => {
-        queueMicrotask(() => {
-          onProgress({ current: 1, total: 1, merchant: "Coffee", status: "", category: null });
-        });
-        return importPromise.then(() => ({
-          type: "complete",
-          imported: 1,
-          skipped: 0,
-          categorized: 0,
-          errors: [],
-        }));
-      },
-    );
-    const user = userEvent.setup();
-    renderWithProviders(
-      <CsvImportDialog accountId={1} accountName="Test" onClose={onClose} />,
-    );
-
-    await advanceToPreview(user, "Date,Merchant,Amount\n2026-01-15,Coffee,4.50\n");
-    await waitFor(() => expect(screen.getByText(/Import 1 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 1 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Importing...")).toBeInTheDocument();
-      expect(screen.getByText("1/1")).toBeInTheDocument();
-    });
-
-    resolveImport!(undefined);
-  });
-
-  it("shows results after import", async () => {
-    mockApi.streamImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 2,
-      skipped: 1,
-      categorized: 1,
-      errors: [],
-    });
-    const user = userEvent.setup();
-    renderWithProviders(
-      <CsvImportDialog accountId={1} accountName="Test" onClose={onClose} />,
-    );
-
-    await advanceToPreview(
-      user,
-      "Date,Description,Amount\n2026-01-15,Coffee,4.50\n2026-01-16,Grocery,42.00\n",
-    );
-
-    await waitFor(() => expect(screen.getByText(/Import 2 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 2 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-      expect(screen.getByText(/2 imported, 1 skipped, 1 auto-categorized/)).toBeInTheDocument();
-    });
-  });
-
-  it("shows errors in results after import", async () => {
-    mockApi.streamImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 1,
-      skipped: 0,
-      categorized: 0,
-      errors: ["Row 1: invalid date 'bad'"],
-    });
-    const user = userEvent.setup();
-    renderWithProviders(
-      <CsvImportDialog accountId={1} accountName="Test" onClose={onClose} />,
-    );
-
-    await advanceToPreview(user, "Date,Description,Amount\n2026-01-15,Coffee,4.50\n");
-    await waitFor(() => expect(screen.getByText(/Import 1 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 1 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-      expect(screen.getByText("Row 1: invalid date 'bad'")).toBeInTheDocument();
-    });
-  });
-
-  it("Done button calls onClose", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(
-      <CsvImportDialog accountId={1} accountName="Test" onClose={onClose} />,
-    );
-    await advanceToPreview(user, "Date,Description,Amount\n2026-01-15,Coffee,4.50\n");
-    await waitFor(() => expect(screen.getByText(/Import 1 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 1 transactions/));
-
-    await waitFor(() => expect(screen.getByText("Done")).toBeInTheDocument());
-    await user.click(screen.getByText("Done"));
-    expect(onClose).toHaveBeenCalled();
   });
 
   it("Back button returns to upload step and resets", async () => {
@@ -312,57 +198,4 @@ describe("CsvImportDialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("triggers auto-categorize after import when uncategorized transactions exist", async () => {
-    mockApi.streamImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 3,
-      skipped: 0,
-      categorized: 1,
-      errors: [],
-    });
-    const user = userEvent.setup();
-    renderWithProviders(
-      <CsvImportDialog accountId={1} accountName="Test" onClose={onClose} />,
-    );
-
-    await advanceToPreview(
-      user,
-      "Date,Description,Amount\n2026-01-15,Coffee,4.50\n2026-01-16,Grocery,42.00\n2026-01-17,Gas,35.00\n",
-    );
-
-    await waitFor(() => expect(screen.getByText(/Import 3 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 3 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-      expect(mockStartAutoCategorize).toHaveBeenCalled();
-    });
-  });
-
-  it("does not trigger auto-categorize when all transactions already categorized", async () => {
-    mockApi.streamImportTransactions.mockResolvedValue({
-      type: "complete",
-      imported: 2,
-      skipped: 0,
-      categorized: 2,
-      errors: [],
-    });
-    const user = userEvent.setup();
-    renderWithProviders(
-      <CsvImportDialog accountId={1} accountName="Test" onClose={onClose} />,
-    );
-
-    await advanceToPreview(
-      user,
-      "Date,Description,Amount\n2026-01-15,Coffee,4.50\n2026-01-16,Grocery,42.00\n",
-    );
-
-    await waitFor(() => expect(screen.getByText(/Import 2 transactions/)).toBeInTheDocument());
-    await user.click(screen.getByText(/Import 2 transactions/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Import complete")).toBeInTheDocument();
-    });
-    expect(mockStartAutoCategorize).not.toHaveBeenCalled();
-  });
 });


### PR DESCRIPTION
## Summary
- CSV import dialogs now close immediately after the user clicks "Import" and hand off to the persistent bottom-right drawer for progress display
- The drawer shows a seamless `importing → categorizing → complete` flow instead of splitting progress between a modal dialog and the drawer
- Added `startImport` and `startBulkImport` methods to the categorization progress provider with automatic chaining into auto-categorize when uncategorized transactions remain

## Test plan
- [x] All 458 frontend tests pass (44 files)
- [x] All 509 backend tests pass (23 files)
- [x] categorization-drawer tests cover importing state, import→complete, import→categorize chain, bulk import
- [x] csv-import-dialog tests verify startImport handoff and dialog close
- [x] bulk-csv-import-dialog tests verify startBulkImport handoff and dialog close
- [ ] Manual: single-account CSV import closes dialog and shows progress in drawer
- [ ] Manual: bulk CSV import closes dialog and shows progress in drawer
- [ ] Manual: after import completes, auto-categorization chains automatically

Made with [Cursor](https://cursor.com)