### PR TITLE
perf: optimize CSV import — preload dups/rules, remove inline LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ npx vitest run tests/sidebar.test.tsx  # run a single file
 
 ### Latest coverage snapshot
 
-- Backend (`pytest --cov=app --cov-report=term`): **86% total** (`4215` statements, `595` missed)
+- Backend (`pytest --cov=app --cov-report=term`): **86% total** (`4201` statements, `600` missed)
 - Frontend (`npx vitest run --coverage`): **76% statements**, **72% branches**, **62% functions**, **77% lines**
 
 ## Environment Variables

--- a/app/categorizer.py
+++ b/app/categorizer.py
@@ -70,20 +70,30 @@ def categorize_by_rules(merchant_name: str, session: Session, user_id: int) -> s
     match "internet").  Multi-word keywords still match as substrings so that
     "whole foods" matches "Whole Foods Market".
     """
+    rules = session.exec(
+        select(CategoryRule).where(CategoryRule.user_id == user_id)
+    ).all()
+    return match_rules(merchant_name, rules)
+
+
+def load_rules(session: Session, user_id: int) -> list:
+    """Load all CategoryRules for a user (call once, pass to match_rules)."""
+    return list(session.exec(
+        select(CategoryRule).where(CategoryRule.user_id == user_id)
+    ).all())
+
+
+def match_rules(merchant_name: str, rules: list) -> str | None:
+    """Pure-Python rule matching against a preloaded rule list (no DB access)."""
     import re
 
     if not merchant_name:
         return None
-
-    rules = session.exec(
-        select(CategoryRule).where(CategoryRule.user_id == user_id)
-    ).all()
     for rule in rules:
         flags = 0 if rule.case_sensitive else re.IGNORECASE
         pattern = r"\b" + re.escape(rule.keyword) + r"\b"
         if re.search(pattern, merchant_name, flags):
             return rule.category
-
     return None
 
 

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -18,7 +18,7 @@ from sqlalchemy import delete as sa_delete
 from sqlmodel import Session, or_, select
 
 from app.auth import get_current_user
-from app.categorizer import categorize_by_rules, categorize_single_llm
+from app.categorizer import load_rules, match_rules
 from app.config import get_settings as get_app_settings
 from app.crypto import decrypt_token, encrypt_token
 from app.database import get_session
@@ -1041,7 +1041,6 @@ class ImportRow(BaseModel):
 
 class ImportRequest(BaseModel):
     transactions: list[ImportRow]
-    skip_llm: bool = False
 
 
 @router.post("/import/{account_id}")
@@ -1059,18 +1058,26 @@ def import_transactions(
     accepts = request.headers.get("accept", "")
     if "application/x-ndjson" in accepts:
         return StreamingResponse(
-            _import_generator(body.transactions, acct, session, user, body.skip_llm),
+            _import_generator(body.transactions, acct, session, user),
             media_type="application/x-ndjson",
         )
-    return _import_sync(body.transactions, acct, session, user, body.skip_llm)
+    return _import_sync(body.transactions, acct, session, user)
 
 
 def _import_sync(
     rows: list[ImportRow], acct: Account, session: Session, user: User,
-    skip_llm: bool = False,
 ) -> dict:
     imported = skipped = categorized = 0
     errors: list[str] = []
+
+    existing = session.exec(
+        select(Transaction.date, Transaction.amount, Transaction.merchant_name).where(
+            Transaction.account_id == acct.id,
+        )
+    ).all()
+    dup_set = {(r[0], r[1], r[2]) for r in existing}
+
+    rules = load_rules(session, user.id)
 
     for row in rows:
         try:
@@ -1079,22 +1086,14 @@ def _import_sync(
             errors.append(f"Invalid date: {row.date}")
             continue
 
-        dup = session.exec(
-            select(Transaction).where(
-                Transaction.account_id == acct.id,
-                Transaction.date == parsed_date,
-                Transaction.amount == Decimal(str(row.amount)),
-                Transaction.merchant_name == row.merchant_name,
-            )
-        ).first()
-        if dup:
+        if (parsed_date, Decimal(str(row.amount)), row.merchant_name) in dup_set:
             skipped += 1
             continue
 
         category = row.category
         auto_cat = False
         if not category:
-            category = categorize_by_rules(row.merchant_name, session, user.id)
+            category = match_rules(row.merchant_name, rules)
             if category:
                 auto_cat = True
 
@@ -1109,13 +1108,7 @@ def _import_sync(
             user_id=user.id,
         )
         session.add(txn)
-
-        if not category and not skip_llm:
-            session.flush()
-            llm_cat = categorize_single_llm(txn, user.id)
-            if llm_cat:
-                txn.category = llm_cat
-                auto_cat = True
+        dup_set.add((parsed_date, Decimal(str(row.amount)), row.merchant_name))
 
         if auto_cat:
             categorized += 1
@@ -1133,11 +1126,19 @@ def _import_sync(
 
 def _import_generator(
     rows: list[ImportRow], acct: Account, session: Session, user: User,
-    skip_llm: bool = False,
 ):
     imported = skipped = categorized = 0
     errors: list[str] = []
     total = len(rows)
+
+    existing = session.exec(
+        select(Transaction.date, Transaction.amount, Transaction.merchant_name).where(
+            Transaction.account_id == acct.id,
+        )
+    ).all()
+    dup_set = {(r[0], r[1], r[2]) for r in existing}
+
+    rules = load_rules(session, user.id)
 
     for idx, row in enumerate(rows, 1):
         status = "imported"
@@ -1152,15 +1153,7 @@ def _import_generator(
                            "merchant": row.merchant_name, "status": "error", "category": None})
             continue
 
-        dup = session.exec(
-            select(Transaction).where(
-                Transaction.account_id == acct.id,
-                Transaction.date == parsed_date,
-                Transaction.amount == Decimal(str(row.amount)),
-                Transaction.merchant_name == row.merchant_name,
-            )
-        ).first()
-        if dup:
+        if (parsed_date, Decimal(str(row.amount)), row.merchant_name) in dup_set:
             skipped += 1
             yield _ndjson({"type": "progress", "current": idx, "total": total,
                            "merchant": row.merchant_name, "status": "skipped", "category": None})
@@ -1168,7 +1161,7 @@ def _import_generator(
 
         cat = row.category
         if not cat:
-            cat = categorize_by_rules(row.merchant_name, session, user.id)
+            cat = match_rules(row.merchant_name, rules)
             if cat:
                 auto_cat = True
 
@@ -1183,14 +1176,7 @@ def _import_generator(
             user_id=user.id,
         )
         session.add(txn)
-
-        if not cat and not skip_llm:
-            session.flush()
-            llm_cat = categorize_single_llm(txn, user.id)
-            if llm_cat:
-                txn.category = llm_cat
-                cat = llm_cat
-                auto_cat = True
+        dup_set.add((parsed_date, Decimal(str(row.amount)), row.merchant_name))
 
         if auto_cat:
             categorized += 1
@@ -1234,7 +1220,6 @@ class BulkImportRequest(BaseModel):
     accounts: list[BulkAccountEntry] = []
     transactions: list[BulkTransactionRow]
     new_categories: list[str] = []
-    skip_llm: bool = False
 
 
 @router.post("/bulk-import")
@@ -1255,10 +1240,10 @@ def bulk_import(
     accepts = request.headers.get("accept", "")
     if "application/x-ndjson" in accepts:
         return StreamingResponse(
-            _bulk_import_generator(body.transactions, account_map, owner_map, session, user_id, body.skip_llm),
+            _bulk_import_generator(body.transactions, account_map, owner_map, session, user_id),
             media_type="application/x-ndjson",
         )
-    return _bulk_import_sync(body.transactions, account_map, owner_map, session, user_id, body.skip_llm)
+    return _bulk_import_sync(body.transactions, account_map, owner_map, session, user_id)
 
 
 def _resolve_accounts(
@@ -1346,10 +1331,26 @@ def _bulk_import_sync(
     owner_map: dict[str, int],
     session: Session,
     user_id: int,
-    skip_llm: bool = False,
 ) -> dict:
     imported = skipped = categorized = 0
     errors: list[str] = []
+
+    all_acct_ids = list(account_map.values())
+    existing = session.exec(
+        select(Transaction.date, Transaction.amount, Transaction.merchant_name,
+               Transaction.account_id, Transaction.user_id).where(
+            Transaction.account_id.in_(all_acct_ids) if all_acct_ids  # type: ignore[union-attr]
+            else Transaction.user_id == user_id,
+        )
+    ).all()
+    dup_set: set[tuple] = set()
+    for r in existing:
+        if r[3]:
+            dup_set.add((r[0], r[1], r[2], "acct", r[3]))
+        else:
+            dup_set.add((r[0], r[1], r[2], "user", r[4]))
+
+    rules = load_rules(session, user_id)
 
     for row in rows:
         try:
@@ -1361,24 +1362,16 @@ def _bulk_import_sync(
         acct_id = account_map.get(row.account_name.lower()) if row.account_name else None
         owner_id = _pick_owner_id(row.owner_name, owner_map, user_id)  # type: ignore[arg-type]
 
-        dup_stmt = select(Transaction).where(
-            Transaction.date == parsed_date,
-            Transaction.amount == Decimal(str(row.amount)),
-            Transaction.merchant_name == row.merchant_name,
-        )
-        if acct_id:
-            dup_stmt = dup_stmt.where(Transaction.account_id == acct_id)
-        else:
-            dup_stmt = dup_stmt.where(Transaction.user_id == owner_id)
-
-        if session.exec(dup_stmt).first():
+        dup_key = (parsed_date, Decimal(str(row.amount)), row.merchant_name,
+                   "acct" if acct_id else "user", acct_id if acct_id else owner_id)
+        if dup_key in dup_set:
             skipped += 1
             continue
 
         category = row.category
         auto_cat = False
         if not category:
-            category = categorize_by_rules(row.merchant_name, session, user_id)  # type: ignore[arg-type]
+            category = match_rules(row.merchant_name, rules)
             if category:
                 auto_cat = True
 
@@ -1394,13 +1387,7 @@ def _bulk_import_sync(
             user_id=owner_id,
         )
         session.add(txn)
-
-        if not category and not skip_llm:
-            session.flush()
-            llm_cat = categorize_single_llm(txn, user_id)
-            if llm_cat:
-                txn.category = llm_cat
-                auto_cat = True
+        dup_set.add(dup_key)
 
         if auto_cat:
             categorized += 1
@@ -1422,11 +1409,27 @@ def _bulk_import_generator(
     owner_map: dict[str, int],
     session: Session,
     user_id: int,
-    skip_llm: bool = False,
 ):
     imported = skipped = categorized = 0
     errors: list[str] = []
     total = len(rows)
+
+    all_acct_ids = list(account_map.values())
+    existing = session.exec(
+        select(Transaction.date, Transaction.amount, Transaction.merchant_name,
+               Transaction.account_id, Transaction.user_id).where(
+            Transaction.account_id.in_(all_acct_ids) if all_acct_ids  # type: ignore[union-attr]
+            else Transaction.user_id == user_id,
+        )
+    ).all()
+    dup_set: set[tuple] = set()
+    for r in existing:
+        if r[3]:
+            dup_set.add((r[0], r[1], r[2], "acct", r[3]))
+        else:
+            dup_set.add((r[0], r[1], r[2], "user", r[4]))
+
+    rules = load_rules(session, user_id)
 
     for idx, row in enumerate(rows, 1):
         status = "imported"
@@ -1444,17 +1447,9 @@ def _bulk_import_generator(
         acct_id = account_map.get(row.account_name.lower()) if row.account_name else None
         owner_id = _pick_owner_id(row.owner_name, owner_map, user_id)  # type: ignore[arg-type]
 
-        dup_stmt = select(Transaction).where(
-            Transaction.date == parsed_date,
-            Transaction.amount == Decimal(str(row.amount)),
-            Transaction.merchant_name == row.merchant_name,
-        )
-        if acct_id:
-            dup_stmt = dup_stmt.where(Transaction.account_id == acct_id)
-        else:
-            dup_stmt = dup_stmt.where(Transaction.user_id == owner_id)
-
-        if session.exec(dup_stmt).first():
+        dup_key = (parsed_date, Decimal(str(row.amount)), row.merchant_name,
+                   "acct" if acct_id else "user", acct_id if acct_id else owner_id)
+        if dup_key in dup_set:
             skipped += 1
             yield _ndjson({"type": "progress", "current": idx, "total": total,
                            "merchant": row.merchant_name, "status": "skipped", "category": None})
@@ -1462,7 +1457,7 @@ def _bulk_import_generator(
 
         cat = row.category
         if not cat:
-            cat = categorize_by_rules(row.merchant_name, session, user_id)  # type: ignore[arg-type]
+            cat = match_rules(row.merchant_name, rules)
             if cat:
                 auto_cat = True
 
@@ -1478,14 +1473,7 @@ def _bulk_import_generator(
             user_id=owner_id,
         )
         session.add(txn)
-
-        if not cat and not skip_llm:
-            session.flush()
-            llm_cat = categorize_single_llm(txn, user_id)
-            if llm_cat:
-                txn.category = llm_cat
-                cat = llm_cat
-                auto_cat = True
+        dup_set.add(dup_key)
 
         if auto_cat:
             categorized += 1

--- a/frontend/components/bulk-csv-import-dialog.tsx
+++ b/frontend/components/bulk-csv-import-dialog.tsx
@@ -188,7 +188,6 @@ export default function BulkCsvImportDialog({ onClose }: Props) {
       ],
       transactions: transactionsForImport,
       new_categories: newCategories,
-      skip_llm: true,
     };
 
     startBulkImport(payload);

--- a/frontend/components/categorization-progress-provider.tsx
+++ b/frontend/components/categorization-progress-provider.tsx
@@ -261,7 +261,6 @@ export function CategorizationProgressProvider({
             setImportTotal(evt.total);
             setImportMerchant(evt.merchant);
           },
-          true,
         )
         .then((complete: ImportCompleteEvent) => {
           const impResult = { imported: complete.imported, skipped: complete.skipped };

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -158,7 +158,6 @@ export interface BulkImportPayload {
     owner_name?: string;
   }[];
   new_categories?: string[];
-  skip_llm?: boolean;
 }
 
 async function streamNdjson<T>(
@@ -787,9 +786,8 @@ export const api = {
     accountId: number,
     rows: { date: string; amount: number; merchant_name: string; category?: string }[],
     onProgress: (event: ImportProgressEvent) => void,
-    skipLlm?: boolean,
   ): Promise<ImportCompleteEvent> =>
-    streamNdjson(`/settings/import/${accountId}`, { transactions: rows, skip_llm: skipLlm }, onProgress),
+    streamNdjson(`/settings/import/${accountId}`, { transactions: rows }, onProgress),
 
   bulkImportTransactions: (
     payload: BulkImportPayload,

--- a/frontend/tests/bulk-csv-import-dialog.test.tsx
+++ b/frontend/tests/bulk-csv-import-dialog.test.tsx
@@ -186,7 +186,6 @@ describe("BulkCsvImportDialog", () => {
         category: "Food & Dining",
         account_name: "Visa",
       });
-      expect(payload.skip_llm).toBe(true);
       expect(onClose).toHaveBeenCalled();
     });
   });

--- a/frontend/tests/categorization-drawer.test.tsx
+++ b/frontend/tests/categorization-drawer.test.tsx
@@ -71,7 +71,6 @@ function BulkImportTrigger() {
           transactions: [
             { date: "2026-01-15", amount: 4.5, merchant_name: "Coffee", account_name: "Visa" },
           ],
-          skip_llm: true,
         })
       }
       disabled={state !== "idle"}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -347,32 +347,14 @@ def test_import_ndjson_streaming(auth_client, session):
     assert complete["imported"] == 1
 
 
-# -- Import LLM fallback ---------------------------------------------------
+# -- Import: no inline LLM (deferred to batch auto-categorize) ------------
 
-def test_import_categorizes_via_llm_fallback(auth_client, session):
-    """When no rule matches, the import falls back to LLM per transaction."""
-    from unittest.mock import MagicMock
-    import json as _json
-
+def test_import_never_calls_llm(auth_client, session):
+    """Import never calls LLM inline — uncategorized txns are left for batch auto-categorize."""
     client, user = auth_client
     acct = make_account(session, user, name="Checking")
 
-    def fake_llm_response(url, **kwargs):
-        body = kwargs.get("json", {})
-        user_msg = body["messages"][1]["content"]
-        input_txns = _json.loads(user_msg)
-        result = [{"id": t["id"], "category": "Entertainment"} for t in input_txns]
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = {
-            "choices": [{"message": {"content": _json.dumps(result)}}]
-        }
-        resp.raise_for_status = MagicMock()
-        return resp
-
-    with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model", 10,
-    )), patch("httpx.post", side_effect=fake_llm_response):
+    with patch("httpx.post") as mock_post:
         resp = client.post(
             f"/api/v1/settings/import/{acct.id}",
             json={"transactions": [
@@ -381,35 +363,21 @@ def test_import_categorizes_via_llm_fallback(auth_client, session):
         )
 
     data = resp.json()
-    assert data["categorized"] == 1
+    assert data["imported"] == 1
+    assert data["categorized"] == 0
+    mock_post.assert_not_called()
     txns = session.exec(select(Transaction).where(Transaction.account_id == acct.id)).all()
-    assert txns[0].category == "Entertainment"
+    assert txns[0].category is None
 
 
-def test_import_streaming_shows_llm_category(auth_client, session):
-    """NDJSON streaming: LLM categorization happens inline so progress shows the category."""
-    from unittest.mock import MagicMock
+def test_import_streaming_never_calls_llm(auth_client, session):
+    """NDJSON streaming import never calls LLM inline."""
     import json as _json
 
     client, user = auth_client
     acct = make_account(session, user, name="Checking")
 
-    def fake_llm_response(url, **kwargs):
-        body = kwargs.get("json", {})
-        user_msg = body["messages"][1]["content"]
-        input_txns = _json.loads(user_msg)
-        result = [{"id": t["id"], "category": "Shopping"} for t in input_txns]
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = {
-            "choices": [{"message": {"content": _json.dumps(result)}}]
-        }
-        resp.raise_for_status = MagicMock()
-        return resp
-
-    with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model", 10,
-    )), patch("httpx.post", side_effect=fake_llm_response):
+    with patch("httpx.post") as mock_post:
         resp = client.post(
             f"/api/v1/settings/import/{acct.id}",
             json={"transactions": [
@@ -420,95 +388,18 @@ def test_import_streaming_shows_llm_category(auth_client, session):
 
     lines = [l for l in resp.text.strip().split("\n") if l]
     progress = _json.loads(lines[0])
-    assert progress["status"] == "categorized"
-    assert progress["category"] == "Shopping"
+    assert progress["status"] == "imported"
+    assert progress["category"] is None
     complete = _json.loads(lines[1])
-    assert complete["categorized"] == 1
-    txns = session.exec(select(Transaction).where(Transaction.account_id == acct.id)).all()
-    assert txns[0].category == "Shopping"
-
-
-def test_import_skips_llm_when_flag_set(auth_client, session):
-    """When skip_llm is true, LLM is never called and transactions stay uncategorized."""
-    from unittest.mock import MagicMock
-
-    client, user = auth_client
-    acct = make_account(session, user, name="Checking")
-
-    with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model", 10,
-    )), patch("httpx.post") as mock_post:
-        resp = client.post(
-            f"/api/v1/settings/import/{acct.id}",
-            json={
-                "transactions": [
-                    {"date": "2026-01-15", "amount": 29.99, "merchant_name": "Target"},
-                ],
-                "skip_llm": True,
-            },
-        )
-
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["imported"] == 1
-    assert data["categorized"] == 0
+    assert complete["categorized"] == 0
     mock_post.assert_not_called()
-    txns = session.exec(select(Transaction).where(Transaction.account_id == acct.id)).all()
-    assert txns[0].category is None
 
 
-def test_bulk_import_skips_llm_when_flag_set(auth_client, session):
-    """When skip_llm is true, bulk import skips LLM and transactions stay uncategorized."""
-    from unittest.mock import MagicMock
-
+def test_bulk_import_never_calls_llm(auth_client, session):
+    """Bulk import never calls LLM inline — deferred to batch auto-categorize."""
     client, user = auth_client
 
-    with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model", 10,
-    )), patch("httpx.post") as mock_post:
-        resp = client.post(
-            "/api/v1/settings/bulk-import",
-            json={
-                "accounts": [],
-                "transactions": [
-                    {"date": "2026-01-15", "amount": 10.00, "merchant_name": "Shop"},
-                ],
-                "skip_llm": True,
-            },
-        )
-
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["imported"] == 1
-    assert data["categorized"] == 0
-    mock_post.assert_not_called()
-    txns = session.exec(select(Transaction).where(Transaction.user_id == user.id)).all()
-    assert txns[0].category is None
-
-
-def test_bulk_import_categorizes_via_llm_fallback(auth_client, session):
-    """Bulk import also falls back to LLM when rules don't match."""
-    from unittest.mock import MagicMock
-    import json as _json
-
-    client, user = auth_client
-
-    def fake_llm_response(url, **kwargs):
-        body = kwargs.get("json", {})
-        user_msg = body["messages"][1]["content"]
-        input_txns = _json.loads(user_msg)
-        result = [{"id": t["id"], "category": "Groceries"} for t in input_txns]
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = {
-            "choices": [{"message": {"content": _json.dumps(result)}}]
-        }
-        resp.raise_for_status = MagicMock()
-        return resp
-
-    with patch("app.categorizer._get_llm_config", return_value=(
-        "http://fake-llm", "fake-key", "test-model", 10,
-    )), patch("httpx.post", side_effect=fake_llm_response):
+    with patch("httpx.post") as mock_post:
         resp = client.post("/api/v1/settings/bulk-import", json={
             "accounts": [],
             "transactions": [
@@ -517,9 +408,32 @@ def test_bulk_import_categorizes_via_llm_fallback(auth_client, session):
         })
 
     data = resp.json()
-    assert data["categorized"] == 1
+    assert data["imported"] == 1
+    assert data["categorized"] == 0
+    mock_post.assert_not_called()
     txns = session.exec(select(Transaction).where(Transaction.user_id == user.id)).all()
-    assert txns[0].category == "Groceries"
+    assert txns[0].category is None
+
+
+def test_import_uses_preloaded_rules_not_per_row_db(auth_client, session):
+    """Import uses match_rules (preloaded) not categorize_by_rules (per-row DB)."""
+    client, user = auth_client
+    acct = make_account(session, user, name="Checking")
+    session.add(CategoryRule(user_id=user.id, keyword="coffee", category="Food & Dining"))
+    session.commit()
+
+    resp = client.post(
+        f"/api/v1/settings/import/{acct.id}",
+        json={"transactions": [
+            {"date": "2026-01-15", "amount": 4.50, "merchant_name": "Coffee Shop"},
+            {"date": "2026-01-16", "amount": 5.00, "merchant_name": "Coffee House"},
+            {"date": "2026-01-17", "amount": 6.00, "merchant_name": "Tea Place"},
+        ]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["categorized"] == 2
+    assert resp.json()["imported"] == 3
 
 
 # -- Bulk CSV import -------------------------------------------------------


### PR DESCRIPTION
## Summary

- Preload existing transactions into a set for O(1) duplicate checking (eliminates ~N SELECT queries per import)
- Load category rules once before the loop via `load_rules`/`match_rules` (eliminates ~N rule queries)
- Remove per-row inline LLM categorization — the unified import drawer already chains into batch auto-categorize
- Remove `skip_llm` parameter from import request models and frontend

## Test plan

- [x] 508 backend tests pass (86% coverage)
- [x] 458 frontend tests pass
- [x] All 32 import-related tests pass

Made with [Cursor](https://cursor.com)