### PR TITLE
feat: prevent duplicate Plaid items

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A self-hosted personal finance platform that aggregates bank accounts via Plaid,
 
 ### Account Management
 - Connect bank accounts, credit cards, loans, and investment accounts via Plaid Link
+- **Duplicate item prevention** -- before exchanging a Plaid Link public token, checks if the user (or household) already has a connection at the same institution; returns a clear error message directing them to manage the existing connection
 - **Sandbox mode indicator** -- when Plaid is configured in sandbox/test mode, a visible banner appears on the Dashboard, Connections page, and during onboarding; the Link Account button shows "Link Demo Account"; the onboarding managed-mode card shows a "(Demo)" tag
 - **Managed or Bring Your Own Plaid** -- hosted instances can offer managed Plaid credentials so users connect instantly; alternatively each household configures its own Plaid API keys in Settings; Plaid and LLM mode can be switched in Settings when no accounts are linked
 - **Managed or Bring Your Own LLM** -- admin can configure app-level LLM credentials for managed AI categorization; users choose managed or BYOK during onboarding; switchable in Settings at any time
@@ -398,7 +399,7 @@ personal-finance/
 | Model | Purpose |
 |-------|---------|
 | `User` | Google OAuth user (google_id, email, name, picture, is_admin, is_disabled, created_at, updated_at) |
-| `PlaidItem` | Bank connection with encrypted access token, status tracking (healthy/error/pending_disconnect/revoked), error code and message |
+| `PlaidItem` | Bank connection with encrypted access token, institution_id for duplicate detection, status tracking (healthy/error/pending_disconnect/revoked), error code and message |
 | `Account` | Bank/credit/loan/investment account with balances, optional `statement_available_day` (1-31) and `last_statement_reminder_sent` for recurring reminders |
 | `Transaction` | Financial transaction (Plaid-synced or manual) |
 | `CategoryRule` | Keyword-to-category mapping for auto-categorization |
@@ -468,7 +469,7 @@ All endpoints are prefixed with `/api/v1`. Authenticated via JWT cookie.
 |--------|------|-------------|
 | POST | `/link-token` | Create a Plaid Link token |
 | POST | `/link-token/update/:id` | Create a Plaid Link token for update mode (re-authentication or account selection via `?account_selection=true`) |
-| POST | `/exchange-token` | Exchange public token for access token |
+| POST | `/exchange-token` | Exchange public token for access token (rejects duplicates via `institution_id`) |
 | POST | `/sync/:plaid_item_id` | Sync transactions for a specific item |
 | POST | `/sync-all` | Sync all linked Plaid items (background) |
 | POST | `/sync-all-stream` | Sync all items with streaming NDJSON progress (sync + categorize phases) |
@@ -677,7 +678,7 @@ python3 -m pytest -v              # verbose output
 python3 -m pytest tests/test_auth.py  # run a single file
 ```
 
-**What's tested (560 tests across 25 files):**
+**What's tested (565 tests across 25 files):**
 
 | File | Tests | Coverage |
 |------|-------|----------|
@@ -690,7 +691,7 @@ python3 -m pytest tests/test_auth.py  # run a single file
 | `test_accounts` | 35 | List, update, unlink, summary, manual create/delete, unlinked Plaid delete, balance update (manual-only restriction), CSV import, cascade delete, negative amounts, inline auto-categorization, statement_available_day (create/update/clear/validate), statement-reminders endpoint (match/no-match/last-day-fallback/auth) |
 | `test_scheduler` | 11 | Statement reminder scheduler job (day match, de-duplication, last-day-of-month fallback, no-accounts), per-household scheduler (reads DB config, no-config skips, disabled skips, multiple households, scoped sync items, scoped reminders) |
 | `test_sync_config` | 13 | Sync config CRUD (get configured/unconfigured/no-household/member-read, create/update/invalid-hour/invalid-minute/non-owner/no-household, delete/non-owner/not-configured/no-household) |
-| `test_plaid` | 28 | Link token, exchange token (success, relink, conflict, institution name, no background sync), sync, sync-all-stream (NDJSON streaming, batch account lookup, update-existing, batch LLM, rules-before-LLM), background sync (batch lookups, batch LLM), auto-create missing accounts (create, activity log, reuse, stream event), items (all Plaid calls mocked) |
+| `test_plaid` | 33 | Link token, exchange token (success, relink, conflict, institution name, no background sync, duplicate institution rejected, different-user allowed, no institution_id skips check, institution_id stored, institution_id in list), sync, sync-all-stream (NDJSON streaming, batch account lookup, update-existing, batch LLM, rules-before-LLM), background sync (batch lookups, batch LLM), auto-create missing accounts (create, activity log, reuse, stream event), items (all Plaid calls mocked) |
 | `test_webhooks` | 22 | Webhook endpoint (store event, reject missing/invalid verification, trigger sync for TRANSACTIONS, skip unknown item, handle ITEM.ERROR), webhook handlers (TRANSACTIONS_REMOVED deletes txns, ITEM.ERROR/LOGIN_REPAIRED/PENDING_DISCONNECT/PENDING_EXPIRATION/USER_PERMISSION_REVOKED update PlaidItem status, NEW_ACCOUNTS_AVAILABLE sets new_accounts status + triggers sync, LIABILITIES.DEFAULT_UPDATE triggers sync, WEBHOOK_UPDATE_ACKNOWLEDGED log-only), admin webhook-events listing (list, admin-required, pagination, filter by type) |
 | `test_plaid_update_mode` | 11 | Update mode link token (success, missing item, wrong user, with account_selection, without account_selection), repair endpoint (sets status healthy, clears errors, triggers sync, missing item, wrong user), list items includes status fields (error, healthy null) |
 | `test_tags` | 13 | CRUD, attach/detach tags, idempotent tagging |
@@ -725,7 +726,7 @@ npm run test:watch                # watch mode
 npx vitest run tests/sidebar.test.tsx  # run a single file
 ```
 
-**What's tested (509 tests across 50 files):**
+**What's tested (511 tests across 50 files):**
 
 | File | Tests | Coverage |
 |------|-------|----------|
@@ -769,7 +770,7 @@ npx vitest run tests/sidebar.test.tsx  # run a single file
 | `review-snippet` | 4 | Loading, empty "all caught up", transaction list, view all link |
 | `dashboard-actions` | 6 | Add Account/Link Account/Add Partner buttons, partner status message, navigation to /accounts?add=true, partner dialog open |
 | `add-partner-dialog` | 6 | Email input and submit, invitePartner API call, onClose on success, error display, close button, hidden when closed |
-| `link-account` | 8 | Idle button, token fetch on click, success message, pluralization, sandbox "Link Demo Account" label, production "Link Account" label, startSync triggered after exchange, Plaid browser state cleared after linking |
+| `link-account` | 10 | Idle button, token fetch on click, success message, pluralization, sandbox "Link Demo Account" label, production "Link Account" label, startSync triggered after exchange, Plaid browser state cleared after linking, institution_id passed to exchangeToken, duplicate item error displayed |
 | `sandbox-banner` | 2 | Test-mode warning text, demo accounts mention |
 | `sandbox-banner-wrapper` | 3 | Renders banner when sandbox, nothing when production, nothing when unconfigured |
 | `onboarding` | 21 | Wizard step 1 (Plaid mode): managed + BYOK cards, hidden managed when unavailable, no auto-selection, setPlaidMode calls on card click, Settings info text, no skip; wizard step 2 (LLM mode): managed AI + BYOK cards, no skip, back button returns to step 1, setLLMMode calls, Settings info text; wizard progression: step indicator, advancement after plaid mode set, skip step 2 when already set, redirect after all steps complete; sandbox indicator: banner when managed sandbox keys, hidden for production; cache invalidation: plaid-config cache cleared on managed and BYOK card click |

--- a/app/models.py
+++ b/app/models.py
@@ -76,6 +76,7 @@ class PlaidItem(SQLModel, table=True):
     encrypted_access_token: str = Field(index=True)
     item_id: str = Field(unique=True, index=True)
     institution_name: Optional[str] = None
+    institution_id: Optional[str] = Field(default=None, index=True)
     status: str = Field(default="healthy")
     plaid_error_code: Optional[str] = None
     plaid_error_message: Optional[str] = None

--- a/app/routes/plaid.py
+++ b/app/routes/plaid.py
@@ -59,6 +59,7 @@ class LinkTokenResponse(BaseModel):
 class ExchangeTokenRequest(BaseModel):
     public_token: str
     institution_name: str | None = None
+    institution_id: str | None = None
 
 
 class ExchangeTokenResponse(BaseModel):
@@ -166,6 +167,21 @@ def exchange_public_token(
     user: User = Depends(get_current_user),
 ):
     """Exchange a public token for an access token and persist the Plaid item."""
+    if body.institution_id:
+        user_scope_ids = set(get_scoped_user_ids(session, user, "household"))
+        existing_item = session.exec(
+            select(PlaidItem).where(
+                PlaidItem.institution_id == body.institution_id,
+                PlaidItem.user_id.in_(user_scope_ids),  # type: ignore[union-attr]
+            )
+        ).first()
+        if existing_item:
+            raise HTTPException(
+                status_code=409,
+                detail=f"{existing_item.institution_name or 'This institution'} is already linked. "
+                       "Use the Connections page to manage your existing connection.",
+            )
+
     client = get_household_plaid_client(session, user)
 
     exchange_request = ItemPublicTokenExchangeRequest(public_token=body.public_token)
@@ -179,6 +195,7 @@ def exchange_public_token(
         encrypted_access_token=encrypt_token(access_token),
         item_id=item_id,
         institution_name=body.institution_name,
+        institution_id=body.institution_id,
     )
     session.add(plaid_item)
     session.flush()
@@ -599,6 +616,7 @@ def list_plaid_items(
             "id": item.id,
             "item_id": item.item_id,
             "institution_name": item.institution_name,
+            "institution_id": item.institution_id,
             "status": item.status,
             "plaid_error_code": item.plaid_error_code,
             "plaid_error_message": item.plaid_error_message,

--- a/frontend/components/link-account.tsx
+++ b/frontend/components/link-account.tsx
@@ -42,10 +42,12 @@ export default function LinkAccount() {
     mutationFn: ({
       publicToken,
       institutionName,
+      institutionId,
     }: {
       publicToken: string;
       institutionName?: string;
-    }) => api.exchangeToken(publicToken, institutionName),
+      institutionId?: string;
+    }) => api.exchangeToken(publicToken, institutionName, institutionId),
     onSuccess: (data) => {
       setResult(data);
       setStatus("done");
@@ -58,18 +60,20 @@ export default function LinkAccount() {
       queryClient.invalidateQueries({ queryKey: ["netWorthHistory"] });
       startSync();
     },
-    onError: () => {
+    onError: (err: Error) => {
       setStatus("idle");
       setLinkToken(null);
+      setLinkError(err.message);
     },
   });
 
   const onSuccess = useCallback(
-    (publicToken: string, metadata: { institution?: { name?: string } | null }) => {
+    (publicToken: string, metadata: { institution?: { name?: string; institution_id?: string } | null }) => {
       setStatus("exchanging");
       exchangeToken.mutate({
         publicToken,
         institutionName: metadata?.institution?.name ?? undefined,
+        institutionId: metadata?.institution?.institution_id ?? undefined,
       });
     },
     [exchangeToken]

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -485,12 +485,13 @@ export const api = {
   repairPlaidItem: (plaidItemId: number) =>
     fetcher<{ status: string }>(`/plaid/items/${plaidItemId}/repair`, { method: "POST" }),
 
-  exchangeToken: (publicToken: string, institutionName?: string) =>
+  exchangeToken: (publicToken: string, institutionName?: string, institutionId?: string) =>
     fetcher<{ item_id: string; accounts_synced: number }>("/plaid/exchange-token", {
       method: "POST",
       body: JSON.stringify({
         public_token: publicToken,
         institution_name: institutionName,
+        ...(institutionId && { institution_id: institutionId }),
       }),
     }),
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -40,6 +40,7 @@ export interface PlaidConnection {
   id: number;
   item_id: string;
   institution_name: string | null;
+  institution_id: string | null;
   status: string;
   plaid_error_code: string | null;
   plaid_error_message: string | null;

--- a/frontend/tests/link-account.test.tsx
+++ b/frontend/tests/link-account.test.tsx
@@ -9,7 +9,9 @@ const mockStartSync = vi.fn();
 let capturedOnSuccess: ((token: string, meta: unknown) => void) | null = null;
 const mockOpen = vi.fn(() => {
   if (capturedOnSuccess) {
-    capturedOnSuccess("public-sandbox-xyz", { institution: { name: "Test Bank" } });
+    capturedOnSuccess("public-sandbox-xyz", {
+      institution: { name: "Test Bank", institution_id: "ins_109508" },
+    });
   }
 });
 
@@ -135,6 +137,38 @@ describe("LinkAccount", () => {
 
     await waitFor(() => {
       expect(mockStartSync).toHaveBeenCalled();
+    });
+  });
+
+  it("passes institution_id to exchangeToken from onSuccess metadata", async () => {
+    const user = userEvent.setup();
+    mockApi.createLinkToken.mockResolvedValue({ link_token: "link-tok" });
+    mockApi.exchangeToken.mockResolvedValue({ item_id: "item-1", accounts_synced: 1 });
+
+    renderWithProviders(<LinkAccount />);
+    await user.click(screen.getByText("Link Account"));
+
+    await waitFor(() => {
+      expect(mockApi.exchangeToken).toHaveBeenCalledWith(
+        "public-sandbox-xyz",
+        "Test Bank",
+        "ins_109508",
+      );
+    });
+  });
+
+  it("shows duplicate item error when exchange returns 409", async () => {
+    const user = userEvent.setup();
+    mockApi.createLinkToken.mockResolvedValue({ link_token: "link-tok" });
+    mockApi.exchangeToken.mockRejectedValue(
+      new Error("Test Bank is already linked. Use the Connections page to manage your existing connection."),
+    );
+
+    renderWithProviders(<LinkAccount />);
+    await user.click(screen.getByText("Link Account"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/already linked/i)).toBeInTheDocument();
     });
   });
 

--- a/tests/test_plaid.py
+++ b/tests/test_plaid.py
@@ -539,6 +539,114 @@ def test_sync_transactions_batch_llm(session):
     mock_batch.assert_called()
 
 
+# -- Duplicate item prevention ---------------------------------------------
+
+
+def test_exchange_token_stores_institution_id(auth_client, session):
+    """institution_id from the request body is persisted on the PlaidItem."""
+    client, user = auth_client
+    mock_client = _mock_plaid_exchange()
+
+    with patch(MOCK_HH_CLIENT, return_value=mock_client):
+        resp = client.post("/api/v1/plaid/exchange-token", json={
+            "public_token": "public-sandbox-abc",
+            "institution_name": "Wells Fargo",
+            "institution_id": "ins_4",
+        })
+
+    assert resp.status_code == 200
+    item = session.exec(
+        select(PlaidItem).where(PlaidItem.user_id == user.id)
+    ).first()
+    assert item.institution_id == "ins_4"
+
+
+def test_exchange_token_duplicate_institution_rejected(auth_client, session):
+    """A 409 is returned when the user already has an item at the same institution."""
+    client, user = auth_client
+
+    existing = PlaidItem(
+        user_id=user.id,
+        encrypted_access_token=encrypt_token("access-existing"),
+        item_id="item-existing-001",
+        institution_name="Wells Fargo",
+        institution_id="ins_4",
+    )
+    session.add(existing)
+    session.commit()
+
+    mock_client = _mock_plaid_exchange()
+    with patch(MOCK_HH_CLIENT, return_value=mock_client):
+        resp = client.post("/api/v1/plaid/exchange-token", json={
+            "public_token": "public-sandbox-abc",
+            "institution_name": "Wells Fargo",
+            "institution_id": "ins_4",
+        })
+
+    assert resp.status_code == 409
+    assert "already linked" in resp.json()["detail"].lower()
+
+
+def test_exchange_token_duplicate_different_user_allowed(auth_client, session):
+    """Different users can link the same institution without conflict."""
+    client, user = auth_client
+    other = make_user(session)
+
+    existing = PlaidItem(
+        user_id=other.id,
+        encrypted_access_token=encrypt_token("access-other"),
+        item_id="item-other-001",
+        institution_name="Wells Fargo",
+        institution_id="ins_4",
+    )
+    session.add(existing)
+    session.commit()
+
+    mock_client = _mock_plaid_exchange()
+    with patch(MOCK_HH_CLIENT, return_value=mock_client):
+        resp = client.post("/api/v1/plaid/exchange-token", json={
+            "public_token": "public-sandbox-abc",
+            "institution_name": "Wells Fargo",
+            "institution_id": "ins_4",
+        })
+
+    assert resp.status_code == 200
+
+
+def test_exchange_token_no_institution_id_skips_duplicate_check(auth_client, session):
+    """When institution_id is not provided, the duplicate check is skipped."""
+    client, user = auth_client
+    mock_client = _mock_plaid_exchange()
+
+    with patch(MOCK_HH_CLIENT, return_value=mock_client):
+        resp = client.post("/api/v1/plaid/exchange-token", json={
+            "public_token": "public-sandbox-abc",
+            "institution_name": "Wells Fargo",
+        })
+
+    assert resp.status_code == 200
+
+
+def test_list_items_includes_institution_id(auth_client, session):
+    """list_plaid_items response includes institution_id."""
+    client, user = auth_client
+    item = PlaidItem(
+        user_id=user.id,
+        encrypted_access_token=encrypt_token("access-test"),
+        item_id="item-inst-id-test",
+        institution_name="Chase",
+        institution_id="ins_3",
+    )
+    session.add(item)
+    session.commit()
+
+    resp = client.get("/api/v1/plaid/items")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["institution_id"] == "ins_3"
+
+
 # -- Exchange-token no background sync ------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Before exchanging a Plaid Link public token, checks if the user (or household) already has a PlaidItem at the same `institution_id` — returns a 409 with a message directing them to the Connections page
- Passes `institution_id` from Plaid Link `onSuccess` metadata through to the backend
- Shows the duplicate error message to the user below the Link Account button

## Test plan
- [x] 5 new backend tests (565 total): institution_id stored, duplicate rejected, different-user allowed, no institution_id skips check, institution_id in list response
- [x] 2 new frontend tests (511 total): institution_id passed from metadata, duplicate error displayed
- [x] Full backend suite passes (87% coverage)
- [x] Full frontend suite passes (50 files)


Made with [Cursor](https://cursor.com)